### PR TITLE
Fix websocket proto

### DIFF
--- a/webapp/src/components/HomeView.vue
+++ b/webapp/src/components/HomeView.vue
@@ -95,7 +95,7 @@ export default defineComponent({
             console.log("Starting connection to WebSocket Server");
 
             const { protocol, host } = location;
-            const webSocketUrl = `${protocol === "https" ? "wss" : "ws"
+            const webSocketUrl = `${protocol === "https:" ? "wss" : "ws"
                 }://${host}/livedata`;
 
             this.socket = new WebSocket(webSocketUrl);


### PR DESCRIPTION
Hi,

auf diesem Weg zuerstmal meinen Respekt. Das RE des Protokolls und diese Firmware war/ist tolle Arbeit von Euch. Und danke für das Offenlegen! 

Einen ersten PR hätte ich: Wenn man das über einen Proxy mit SSL aufruft klappt der Websocket nicht. Der Test aktuell ist `location.proto === "https"`. `proto` enthält aber den Doppelpunkt, also `https:`.

Ich habe jetzt im PR nur die Sourcen drin, nicht den build.

Gruß
Axel