### PR TITLE
Problem beim Build mit Leerzeichen im Usernamen

### DIFF
--- a/auto_firmware_version.py
+++ b/auto_firmware_version.py
@@ -11,7 +11,7 @@ installed_pkgs = {pkg.key for pkg in pkg_resources.working_set}
 missing_pkgs = required_pkgs - installed_pkgs
 
 if missing_pkgs:
-    env.Execute('$PYTHONEXE -m pip install dulwich --global-option="--pure"')
+    env.Execute('"$PYTHONEXE" -m pip install dulwich --global-option="--pure"')
 
 from dulwich import porcelain
 


### PR DESCRIPTION
Wenn der Username aus Vor- und Nachname mit Leerzeichen besteht, funktioniert das Build nicht:
`Executing task: C:\Users\X Y\.platformio\penv\Scripts\platformio.exe run 

Processing generic (board: esp32dev; framework: arduino; platform: espressif32@>4)
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------Verbose mode can be enabled via `-v, --verbose` option
C:\Users\X Y\.platformio\penv\Scripts\python.exe -m pip install dulwich --global-option="--pure"
Der Befehl "C:\Users\Klaus" ist entweder falsch geschrieben oder
konnte nicht gefunden werden.`
Mit dieser kleinen Änderung ("$PYTHONEXE") läuft es durch und sollte keine Auswirkungen auf andere Installationen haben!