### PR TITLE
fix static code analysis warnings

### DIFF
--- a/lib/Hoymiles/src/Hoymiles.h
+++ b/lib/Hoymiles/src/Hoymiles.h
@@ -28,7 +28,7 @@ private:
     std::vector<std::shared_ptr<InverterAbstract>> _inverters;
     std::unique_ptr<HoymilesRadio> _radio;
 
-    uint32_t _pollInterval;
+    uint32_t _pollInterval = 0;
     uint32_t _lastPoll = 0;
 };
 

--- a/lib/Hoymiles/src/HoymilesRadio.h
+++ b/lib/Hoymiles/src/HoymilesRadio.h
@@ -75,12 +75,12 @@ private:
     std::unique_ptr<SPIClass> _hspi;
     std::unique_ptr<RF24> _radio;
     uint8_t _rxChLst[5] = { 3, 23, 40, 61, 75 };
-    uint8_t _rxChIdx;
+    uint8_t _rxChIdx = 0;
 
     uint8_t _txChLst[5] = { 3, 23, 40, 61, 75 };
-    uint8_t _txChIdx;
+    uint8_t _txChIdx = 0;
 
-    volatile bool _packetReceived;
+    volatile bool _packetReceived = false;
 
     CircularBuffer<fragment_t, FRAGMENT_BUFFER_SIZE> _rxBuffer;
     TimeoutHelper _rxTimeout;

--- a/lib/Hoymiles/src/commands/AlarmDataCommand.h
+++ b/lib/Hoymiles/src/commands/AlarmDataCommand.h
@@ -6,5 +6,5 @@ class AlarmDataCommand : public MultiDataCommand {
 public:
     AlarmDataCommand(uint64_t target_address = 0, uint64_t router_address = 0, time_t time = 0);
 
-    virtual bool handleResponse(InverterAbstract* inverter, fragment_t fragment[], uint8_t max_fragment_id);
+    virtual bool handleResponse(InverterAbstract* inverter, fragment_t fragment[], uint8_t max_fragment_id) override;
 };

--- a/lib/Hoymiles/src/commands/DevInfoAllCommand.h
+++ b/lib/Hoymiles/src/commands/DevInfoAllCommand.h
@@ -6,5 +6,5 @@ class DevInfoAllCommand : public MultiDataCommand {
 public:
     DevInfoAllCommand(uint64_t target_address = 0, uint64_t router_address = 0, time_t time = 0);
 
-    virtual bool handleResponse(InverterAbstract* inverter, fragment_t fragment[], uint8_t max_fragment_id);
+    virtual bool handleResponse(InverterAbstract* inverter, fragment_t fragment[], uint8_t max_fragment_id) override;
 };

--- a/lib/Hoymiles/src/commands/DevInfoSampleCommand.h
+++ b/lib/Hoymiles/src/commands/DevInfoSampleCommand.h
@@ -6,5 +6,5 @@ class DevInfoSampleCommand : public MultiDataCommand {
 public:
     DevInfoSampleCommand(uint64_t target_address = 0, uint64_t router_address = 0, time_t time = 0);
 
-    virtual bool handleResponse(InverterAbstract* inverter, fragment_t fragment[], uint8_t max_fragment_id);
+    virtual bool handleResponse(InverterAbstract* inverter, fragment_t fragment[], uint8_t max_fragment_id) override;
 };

--- a/lib/Hoymiles/src/commands/MultiDataCommand.h
+++ b/lib/Hoymiles/src/commands/MultiDataCommand.h
@@ -11,9 +11,9 @@ public:
     void setTime(time_t time);
     time_t getTime();
 
-    CommandAbstract* getRequestFrameCommand(uint8_t frame_no);
+    CommandAbstract* getRequestFrameCommand(uint8_t frame_no) override;
 
-    virtual bool handleResponse(InverterAbstract* inverter, fragment_t fragment[], uint8_t max_fragment_id);
+    virtual bool handleResponse(InverterAbstract* inverter, fragment_t fragment[], uint8_t max_fragment_id) override;
 
 protected:
     void setDataType(uint8_t data_type);

--- a/lib/Hoymiles/src/commands/RealTimeRunDataCommand.h
+++ b/lib/Hoymiles/src/commands/RealTimeRunDataCommand.h
@@ -6,5 +6,5 @@ class RealTimeRunDataCommand : public MultiDataCommand {
 public:
     RealTimeRunDataCommand(uint64_t target_address = 0, uint64_t router_address = 0, time_t time = 0);
 
-    virtual bool handleResponse(InverterAbstract* inverter, fragment_t fragment[], uint8_t max_fragment_id);
+    virtual bool handleResponse(InverterAbstract* inverter, fragment_t fragment[], uint8_t max_fragment_id) override;
 };

--- a/lib/Hoymiles/src/commands/RequestFrameCommand.h
+++ b/lib/Hoymiles/src/commands/RequestFrameCommand.h
@@ -9,5 +9,5 @@ public:
     void setFrameNo(uint8_t frame_no);
     uint8_t getFrameNo();
 
-    virtual bool handleResponse(InverterAbstract* inverter, fragment_t fragment[], uint8_t max_fragment_id);
+    virtual bool handleResponse(InverterAbstract* inverter, fragment_t fragment[], uint8_t max_fragment_id) override;
 };

--- a/lib/Hoymiles/src/crc.cpp
+++ b/lib/Hoymiles/src/crc.cpp
@@ -1,6 +1,6 @@
 #include "crc.h"
 
-uint8_t crc8(uint8_t buf[], uint8_t len)
+uint8_t crc8(const uint8_t buf[], uint8_t len)
 {
     uint8_t crc = CRC8_INIT;
     for (uint8_t i = 0; i < len; i++) {
@@ -12,10 +12,10 @@ uint8_t crc8(uint8_t buf[], uint8_t len)
     return crc;
 }
 
-uint16_t crc16(uint8_t buf[], uint8_t len, uint16_t start)
+uint16_t crc16(const uint8_t buf[], uint8_t len, uint16_t start)
 {
     uint16_t crc = start;
-    uint8_t shift = 0;
+    uint8_t shift;
 
     for (uint8_t i = 0; i < len; i++) {
         crc = crc ^ buf[i];
@@ -29,7 +29,7 @@ uint16_t crc16(uint8_t buf[], uint8_t len, uint16_t start)
     return crc;
 }
 
-uint16_t crc16nrf24(uint8_t buf[], uint16_t lenBits, uint16_t startBit, uint16_t crcIn)
+uint16_t crc16nrf24(const uint8_t buf[], uint16_t lenBits, uint16_t startBit, uint16_t crcIn)
 {
     uint16_t crc = crcIn;
     uint8_t idx, val = buf[(startBit >> 3)];

--- a/lib/Hoymiles/src/crc.h
+++ b/lib/Hoymiles/src/crc.h
@@ -8,6 +8,6 @@
 #define CRC16_MODBUS_POLYNOM 0xA001
 #define CRC16_NRF24_POLYNOM 0x1021
 
-uint8_t crc8(uint8_t buf[], uint8_t len);
-uint16_t crc16(uint8_t buf[], uint8_t len, uint16_t start = 0xffff);
-uint16_t crc16nrf24(uint8_t buf[], uint16_t lenBits, uint16_t startBit = 0, uint16_t crcIn = 0xffff);
+uint8_t crc8(const uint8_t buf[], uint8_t len);
+uint16_t crc16(const uint8_t buf[], uint8_t len, uint16_t start = 0xffff);
+uint16_t crc16nrf24(const uint8_t buf[], uint16_t lenBits, uint16_t startBit = 0, uint16_t crcIn = 0xffff);

--- a/lib/Hoymiles/src/inverters/HM_1CH.h
+++ b/lib/Hoymiles/src/inverters/HM_1CH.h
@@ -6,9 +6,9 @@ class HM_1CH : public HM_Abstract {
 public:
     HM_1CH(uint64_t serial);
     static bool isValidSerial(uint64_t serial);
-    String typeName();
-    const byteAssign_t* getByteAssignment();
-    const uint8_t getAssignmentCount();
+    String typeName() override;
+    const byteAssign_t* getByteAssignment() override;
+    const uint8_t getAssignmentCount() override;
 
 private:
     const byteAssign_t byteAssignment[17] = {

--- a/lib/Hoymiles/src/inverters/HM_2CH.h
+++ b/lib/Hoymiles/src/inverters/HM_2CH.h
@@ -6,9 +6,9 @@ class HM_2CH : public HM_Abstract {
 public:
     HM_2CH(uint64_t serial);
     static bool isValidSerial(uint64_t serial);
-    String typeName();
-    const byteAssign_t* getByteAssignment();
-    const uint8_t getAssignmentCount();
+    String typeName() override;
+    const byteAssign_t* getByteAssignment() override;
+    const uint8_t getAssignmentCount() override;
 
 private:
     const byteAssign_t byteAssignment[23] = {

--- a/lib/Hoymiles/src/inverters/HM_4CH.h
+++ b/lib/Hoymiles/src/inverters/HM_4CH.h
@@ -6,9 +6,9 @@ class HM_4CH : public HM_Abstract {
 public:
     HM_4CH(uint64_t serial);
     static bool isValidSerial(uint64_t serial);
-    String typeName();
-    const byteAssign_t* getByteAssignment();
-    const uint8_t getAssignmentCount();
+    String typeName() override;
+    const byteAssign_t* getByteAssignment() override;
+    const uint8_t getAssignmentCount() override;
 
 private:
     const byteAssign_t byteAssignment[36] = {

--- a/lib/Hoymiles/src/inverters/HM_Abstract.h
+++ b/lib/Hoymiles/src/inverters/HM_Abstract.h
@@ -5,9 +5,9 @@
 class HM_Abstract : public InverterAbstract {
 public:
     HM_Abstract(uint64_t serial);
-    bool sendStatsRequest(HoymilesRadio* radio);
-    bool sendAlarmLogRequest(HoymilesRadio* radio);
-    bool sendDevInfoRequest(HoymilesRadio* radio);
+    bool sendStatsRequest(HoymilesRadio* radio) override;
+    bool sendAlarmLogRequest(HoymilesRadio* radio) override;
+    bool sendDevInfoRequest(HoymilesRadio* radio) override;
 
 private:
     uint8_t _lastAlarmLogCnt = 0;

--- a/lib/Hoymiles/src/inverters/InverterAbstract.h
+++ b/lib/Hoymiles/src/inverters/InverterAbstract.h
@@ -47,7 +47,7 @@ public:
 
 private:
     serial_u _serial;
-    char _name[MAX_NAME_LENGTH];
+    char _name[MAX_NAME_LENGTH] = {};
     fragment_t _rxFragmentBuffer[MAX_RF_FRAGMENT_COUNT];
     uint8_t _rxFragmentMaxPacketId = 0;
     uint8_t _rxFragmentLastPacketId = 0;

--- a/lib/Hoymiles/src/parser/AlarmLogParser.cpp
+++ b/lib/Hoymiles/src/parser/AlarmLogParser.cpp
@@ -30,12 +30,12 @@ void AlarmLogParser::getLogEntry(uint8_t entryId, AlarmLogEntry_t* entry)
 
     uint32_t wcode = (uint16_t)_payloadAlarmLog[entryStartOffset] << 8 | _payloadAlarmLog[entryStartOffset + 1];
     uint32_t startTimeOffset = 0;
-    if ((wcode >> 13) & 0x01 == 1) {
+    if (((wcode >> 13) & 0x01) == 1) {
         startTimeOffset = 12 * 60 * 60;
     }
 
     uint32_t endTimeOffset = 0;
-    if ((wcode >> 12) & 0x01 == 1) {
+    if (((wcode >> 12) & 0x01) == 1) {
         endTimeOffset = 12 * 60 * 60;
     }
 

--- a/lib/Hoymiles/src/parser/AlarmLogParser.h
+++ b/lib/Hoymiles/src/parser/AlarmLogParser.h
@@ -24,6 +24,6 @@ public:
 private:
     static int getTimezoneOffset();
 
-    uint8_t _payloadAlarmLog[ALARM_LOG_ENTRY_SIZE * ALARM_LOG_ENTRY_COUNT];
-    uint8_t _alarmLogLength;
+    uint8_t _payloadAlarmLog[ALARM_LOG_ENTRY_SIZE * ALARM_LOG_ENTRY_COUNT] = {};
+    uint8_t _alarmLogLength = 0;
 };

--- a/lib/Hoymiles/src/parser/DevInfoParser.h
+++ b/lib/Hoymiles/src/parser/DevInfoParser.h
@@ -30,9 +30,9 @@ private:
     uint32_t _lastUpdateAll = 0;
     uint32_t _lastUpdateSample = 0;
 
-    uint8_t _payloadDevInfoAll[DEV_INFO_SIZE];
-    uint8_t _devInfoAllLength;
+    uint8_t _payloadDevInfoAll[DEV_INFO_SIZE] = {};
+    uint8_t _devInfoAllLength = 0;
 
-    uint8_t _payloadDevInfoSample[DEV_INFO_SIZE];
-    uint8_t _devInfoSampleLength;
+    uint8_t _payloadDevInfoSample[DEV_INFO_SIZE] = {};
+    uint8_t _devInfoSampleLength = 0;
 };

--- a/lib/Hoymiles/src/parser/StatisticsParser.h
+++ b/lib/Hoymiles/src/parser/StatisticsParser.h
@@ -114,9 +114,9 @@ public:
     void setChannelMaxPower(uint8_t channel, uint16_t power);
 
 private:
-    uint8_t _payloadStatistic[STATISTIC_PACKET_SIZE];
-    uint8_t _statisticLength;
-    uint16_t _chanMaxPower[CH4];
+    uint8_t _payloadStatistic[STATISTIC_PACKET_SIZE] = {};
+    uint8_t _statisticLength = 0;
+    uint16_t _chanMaxPower[CH4] = {};
 
     const byteAssign_t* _byteAssignment;
     uint8_t _byteAssignmentCount;

--- a/src/MqttHassPublishing.cpp
+++ b/src/MqttHassPublishing.cpp
@@ -74,7 +74,7 @@ void MqttHassPublishingClass::publishField(std::shared_ptr<InverterAbstract> inv
     }
 
     char serial[sizeof(uint64_t) * 8 + 1];
-    sprintf(serial, "%0lx%08lx",
+    sprintf(serial, "%0x%08x",
         ((uint32_t)((inv->serial() >> 32) & 0xFFFFFFFF)),
         ((uint32_t)(inv->serial() & 0xFFFFFFFF)));
 

--- a/src/MqttPublishing.cpp
+++ b/src/MqttPublishing.cpp
@@ -30,7 +30,7 @@ void MqttPublishingClass::loop()
             auto inv = Hoymiles.getInverterByPos(i);
 
             char buffer[sizeof(uint64_t) * 8 + 1];
-            sprintf(buffer, "%0lx%08lx",
+            sprintf(buffer, "%0x%08x",
                 ((uint32_t)((inv->serial() >> 32) & 0xFFFFFFFF)),
                 ((uint32_t)(inv->serial() & 0xFFFFFFFF)));
             String subtopic = String(buffer);
@@ -94,7 +94,7 @@ String MqttPublishingClass::getTopic(std::shared_ptr<InverterAbstract> inv, uint
     }
 
     char buffer[sizeof(uint64_t) * 8 + 1];
-    sprintf(buffer, "%0lx%08lx",
+    sprintf(buffer, "%0x%08x",
         ((uint32_t)((inv->serial() >> 32) & 0xFFFFFFFF)),
         ((uint32_t)(inv->serial() & 0xFFFFFFFF)));
     String invSerial = String(buffer);

--- a/src/WebApi_devinfo.cpp
+++ b/src/WebApi_devinfo.cpp
@@ -31,7 +31,7 @@ void WebApiDevInfoClass::onDevInfoStatus(AsyncWebServerRequest* request)
 
         // Inverter Serial is read as HEX
         char buffer[sizeof(uint64_t) * 8 + 1];
-        sprintf(buffer, "%0lx%08lx",
+        sprintf(buffer, "%0x%08x",
             ((uint32_t)((inv->serial() >> 32) & 0xFFFFFFFF)),
             ((uint32_t)(inv->serial() & 0xFFFFFFFF)));
 

--- a/src/WebApi_dtu.cpp
+++ b/src/WebApi_dtu.cpp
@@ -30,7 +30,7 @@ void WebApiDtuClass::onDtuAdminGet(AsyncWebServerRequest* request)
 
     // DTU Serial is read as HEX
     char buffer[sizeof(uint64_t) * 8 + 1];
-    sprintf(buffer, "%0lx%08lx",
+    sprintf(buffer, "%0ux%08ux",
         ((uint32_t)((config.Dtu_Serial >> 32) & 0xFFFFFFFF)),
         ((uint32_t)(config.Dtu_Serial & 0xFFFFFFFF)));
     root[F("dtu_serial")] = buffer;

--- a/src/WebApi_eventlog.cpp
+++ b/src/WebApi_eventlog.cpp
@@ -30,7 +30,7 @@ void WebApiEventlogClass::onEventlogStatus(AsyncWebServerRequest* request)
 
         // Inverter Serial is read as HEX
         char buffer[sizeof(uint64_t) * 8 + 1];
-        sprintf(buffer, "%0lx%08lx",
+        sprintf(buffer, "%0x%08x",
             ((uint32_t)((inv->serial() >> 32) & 0xFFFFFFFF)),
             ((uint32_t)(inv->serial() & 0xFFFFFFFF)));
 

--- a/src/WebApi_inverter.cpp
+++ b/src/WebApi_inverter.cpp
@@ -42,7 +42,7 @@ void WebApiInverterClass::onInverterList(AsyncWebServerRequest* request)
 
             // Inverter Serial is read as HEX
             char buffer[sizeof(uint64_t) * 8 + 1];
-            sprintf(buffer, "%0lx%08lx",
+            sprintf(buffer, "%0x%08x",
                 ((uint32_t)((config.Inverter[i].Serial >> 32) & 0xFFFFFFFF)),
                 ((uint32_t)(config.Inverter[i].Serial & 0xFFFFFFFF)));
             obj[F("serial")] = buffer;

--- a/src/WebApi_ws_live.cpp
+++ b/src/WebApi_ws_live.cpp
@@ -74,7 +74,7 @@ void WebApiWsLiveClass::generateJsonResponse(JsonVariant& root)
         auto inv = Hoymiles.getInverterByPos(i);
 
         char buffer[sizeof(uint64_t) * 8 + 1];
-        sprintf(buffer, "%0lx%08lx",
+        sprintf(buffer, "%0x%08x",
             ((uint32_t)((inv->serial() >> 32) & 0xFFFFFFFF)),
             ((uint32_t)(inv->serial() & 0xFFFFFFFF)));
 


### PR DESCRIPTION
still looking for the culprit behind https://github.com/tbnobody/OpenDTU/issues/83 

some findings from cppcheck fixed

- lots of initialization stuff
- overrides
- const for buffer parameters

actual logic changes
- in lib/Hoymiles/src/parser/AlarmLogParser.cpp
- all the places printing the inverter serial as hex string
