### PR TITLE
src/Configuration.cpp: fix homeassistant discovery config

### DIFF
--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -54,7 +54,7 @@ void ConfigurationClass::init()
 
     config.Mqtt_Hass_Enabled = MQTT_HASS_ENABLED;
     config.Mqtt_Hass_Retain = MQTT_HASS_RETAIN;
-    strlcpy(config.Mqtt_Hass_Topic, MQTT_TOPIC, sizeof(config.Mqtt_Hass_Topic));
+    strlcpy(config.Mqtt_Hass_Topic, MQTT_HASS_TOPIC, sizeof(config.Mqtt_Hass_Topic));
     config.Mqtt_Hass_IndividualPanels = MQTT_HASS_INDIVIDUALPANELS;
 }
 


### PR DESCRIPTION
On a fresh installed openDTU esp32, the mqtt discovery prefix
topic does not match the default value of homeassistant, due to a wrong
assignment in src/Configuration.cpp.
This patch fixes it.

Signed-off-by: Martin Dummer <martin.dummer@gmx.net>