### PR TITLE
add supported inverters (TSUN TSOL M350)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ It was the goal to replace the original Hoymiles DTU (Telemetry Gateway) with th
 * Hoymiles HM-1000
 * Hoymiles HM-1200
 * Hoymiles HM-1500
+* TSUN TSOL-M350 (Maybe depending on firmware on the inverter)
 * TSUN TSOL-M800 (Maybe depending on firmware on the inverter)
 
 ## Features for end users


### PR DESCRIPTION
I can confirm that the TSUN TSOL M350 is in principle supported (at least some versions):

I tested it with a TSUN TSOL M350 with the following properties:

Parameter | Value
-------- | -------- 
Serial Number | 11xxxxxxxxxx
Bootloader Version | 0.1.2
Firmware Version | 1.0.14
Firmware Build Date | 2021-12-09 12:46:00
Hardware Part Number | REDACTED
Hardware Version | 512


