### PR TITLE
BREAKING CHANGE: add dtu serial to mqtt status topics

### DIFF
--- a/docs/MQTT_Topics.md
+++ b/docs/MQTT_Topics.md
@@ -4,13 +4,15 @@ The base topic, as configured in the web GUI is prepended to all follwing topics
 
 ## General topics
 
+serial will be replaced with the serial number of the OpenDTU device.
+
 | Topic                                   | R / W | Description                                          | Value / Unit               |
 | --------------------------------------- | ----- | ---------------------------------------------------- | -------------------------- |
-| dtu/ip                                  | R     | IP address of OpenDTU                                | IP address                 |
-| dtu/hostname                            | R     | Current hostname of the dtu (as set in web GUI)      |                            |
-| dtu/rssi                                | R     | WiFi network quality                                 | db value                   |
+| dtu/[serial]/ip                         | R     | IP address of OpenDTU                                | IP address                 |
+| dtu/[serial]/hostname                   | R     | Current hostname of the dtu (as set in web GUI)      |                            |
+| dtu/[serial]/rssi                       | R     | WiFi network quality                                 | db value                   |
 | dtu/status                              | R     | Indicates whether OpenDTU network is reachable       | online /  offline          |
-| dtu/uptime                              | R     | Time in seconds since startup                        | seconds                    |
+| dtu/[serial]/uptime                     | R     | Time in seconds since startup                        | seconds                    |
 
 ## Inverter specific topics
 


### PR DESCRIPTION
### +++WIP+++

When two OpenDTU devices are connected to one mqtt broker, it is not possible
to distinguish the status topics between these two devices.

The status topics are composed like

`<base topic>/dtu/<status item>`

example:

```
solar/dtu/rssi -61
solar/dtu/uptime 395
solar/dtu/ip 192.168.166.189
solar/dtu/hostname OpenDTU-8E1C80
solar/dtu/rssi -59
solar/dtu/uptime 7472
solar/dtu/ip 192.168.166.192
solar/dtu/hostname OpenDTU-83B278
```

proposed solution:

insert dtu serial into the status topics like

`<base topic>/dtu/<dtu serial>/<status item>`

```
solar/dtu/199980113408/uptime 2838
solar/dtu/199980113408/ip 192.168.166.189
solar/dtu/199980113408/hostname OpenDTU-8E1C80
solar/dtu/199980113408/rssi -56
```

BUT:

what to do with the configurable  LWT topic `solar/dtu/status` ?

I did not touch this yet. I see two options:
- add a placeholder variable for the serial number to the configurable default, like `solar` / `dtu/#SERIAL#/status` 
- remove the LWT topic from configuration (why is this configurable anyhow?)

What do you think?