### PR TITLE
Support for NodeMCU-ESP-S3-12K-Kit added

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -111,3 +111,14 @@ build_flags = ${env.build_flags}
     -DETH_ADDR=0
     -DETH_MDC_PIN=23
     -DETH_MDIO_PIN=18
+
+[env:esp_s3_12k_kit]
+; https://www.waveshare.com/wiki/NodeMCU-ESP-S3-12K-Kit
+board = esp32-s3-devkitc-1
+build_flags = ${env.build_flags}
+    -DHOYMILES_PIN_MISO=16
+    -DHOYMILES_PIN_MOSI=17
+    -DHOYMILES_PIN_SCLK=18
+    -DHOYMILES_PIN_IRQ=3
+    -DHOYMILES_PIN_CE=4
+    -DHOYMILES_PIN_CS=5


### PR DESCRIPTION
I added support for the AI-Thinker NodeMCU-ESP-S3-12K-Kit and tested it with an HM-1200.