### PR TITLE
Clarify ReadOnly

### DIFF
--- a/webapp/src/locales/de.json
+++ b/webapp/src/locales/de.json
@@ -315,7 +315,7 @@
         "RepeatPassword": "Passwort wiederholen:",
         "PasswordHint": "<b>Hinweis:</b> Das Administrator-Passwort wird für den Zugriff auf die Webschnittstelle (Benutzer 'admin'), aber auch für die Verbindung mit dem Gerät im AP-Modus verwendet. Es muss 8..64 Zeichen lang sein.",
         "Permissions": "Berechtigungen",
-        "ReadOnly": "Nur-Lese-Zugriff auf die Weboberfläche zulassen",
+        "ReadOnly": "Nur-Lese-Zugriff auf die Weboberfläche ohne Passwort zulassen",
         "Save": "@:dtuadmin.Save"
     },
     "ntpadmin": {

--- a/webapp/src/locales/en.json
+++ b/webapp/src/locales/en.json
@@ -315,7 +315,7 @@
         "RepeatPassword": "Repeat Password:",
         "PasswordHint": "<b>Hint:</b> The administrator password is used to access this web interface (user 'admin'), but also to connect to the device when in AP mode. It must be 8..64 characters.",
         "Permissions": "Permissions",
-        "ReadOnly": "Allow readonly access to web interface",
+        "ReadOnly": "Allow readonly access to web interface without password",
         "Save": "@:dtuadmin.Save"
     },
     "ntpadmin": {

--- a/webapp/src/locales/fr.json
+++ b/webapp/src/locales/fr.json
@@ -317,7 +317,7 @@
         "RepeatPassword": "Répéter le mot de passe",
         "PasswordHint": "<b>Astuce :</b> Le mot de passe administrateur est utilisé pour accéder à cette interface web (utilisateur 'admin'), mais aussi pour se connecter à l'appareil en mode AP. Il doit comporter de 8 à 64 caractères.",
         "Permissions": "Autorisations",
-        "ReadOnly": "Autoriser l'accès en lecture seule à l'interface web",
+        "ReadOnly": "Autoriser l'accès en lecture seule à l'interface web sans mot de passe",
         "Save": "@:dtuadmin.Save"
     },
     "ntpadmin": {


### PR DESCRIPTION
Clarify that "Allow readonly access to web interface" means without the admin password set above. 