### PR TITLE
Fix prometheus counters

### DIFF
--- a/lib/Hoymiles/src/parser/StatisticsParser.cpp
+++ b/lib/Hoymiles/src/parser/StatisticsParser.cpp
@@ -130,6 +130,12 @@ const char* StatisticsParser::getChannelFieldName(ChannelType_t type, ChannelNum
     return fields[pos->fieldId];
 }
 
+const char* StatisticsParser::getChannelFieldMetricType(ChannelType_t type, ChannelNum_t channel, FieldId_t fieldId)
+{
+    const byteAssign_t* pos = getAssignmentByChannelField(type, channel, fieldId);
+    return field_metric_types[pos->fieldId];
+}
+
 uint8_t StatisticsParser::getChannelFieldDigits(ChannelType_t type, ChannelNum_t channel, FieldId_t fieldId)
 {
     const byteAssign_t* pos = getAssignmentByChannelField(type, channel, fieldId);

--- a/lib/Hoymiles/src/parser/StatisticsParser.h
+++ b/lib/Hoymiles/src/parser/StatisticsParser.h
@@ -43,6 +43,9 @@ enum FieldId_t {
 const char* const fields[] = { "Voltage", "Current", "Power", "YieldDay", "YieldTotal",
     "Voltage", "Current", "Power", "Frequency", "Temperature", "PowerFactor", "Efficiency", "Irradiation", "ReactivePower", "EventLogCount" };
 
+const char* const field_metric_types[] = { "gauge", "gauge", "gauge", "counter", "counter",
+    "gauge", "gauge", "gauge", "gauge", "gauge", "gauge", "gauge", "gauge", "gauge", "counter" };
+
 // indices to calculation functions, defined in hmInverter.h
 enum {
     CALC_YT_CH0 = 0,
@@ -103,6 +106,7 @@ public:
     bool hasChannelFieldValue(ChannelType_t type, ChannelNum_t channel, FieldId_t fieldId);
     const char* getChannelFieldUnit(ChannelType_t type, ChannelNum_t channel, FieldId_t fieldId);
     const char* getChannelFieldName(ChannelType_t type, ChannelNum_t channel, FieldId_t fieldId);
+    const char* getChannelFieldMetricType(ChannelType_t type, ChannelNum_t channel, FieldId_t fieldId);
     uint8_t getChannelFieldDigits(ChannelType_t type, ChannelNum_t channel, FieldId_t fieldId);
 
     float getChannelFieldOffset(ChannelType_t type, ChannelNum_t channel, FieldId_t fieldId);

--- a/src/WebApi_prometheus.cpp
+++ b/src/WebApi_prometheus.cpp
@@ -96,7 +96,7 @@ void WebApiPrometheusClass::addField(AsyncResponseStream* stream, String& serial
         const char* chanName = (channelName == NULL) ? inv->Statistics()->getChannelFieldName(type, channel, fieldId) : channelName;
         if (idx == 0 && type == TYPE_AC && channel == 0) {
             stream->printf("# HELP opendtu_%s in %s\n", chanName, inv->Statistics()->getChannelFieldUnit(type, channel, fieldId));
-            stream->printf("# TYPE opendtu_%s gauge\n", chanName);
+            stream->printf("# TYPE opendtu_%s %s\n", chanName, inv->Statistics()->getChannelFieldMetricType(type, channel, fieldId));
         }
         stream->printf("opendtu_%s{serial=\"%s\",unit=\"%d\",name=\"%s\",type=\"%s\",channel=\"%d\"} %f\n",
             chanName,

--- a/src/WebApi_prometheus.cpp
+++ b/src/WebApi_prometheus.cpp
@@ -62,27 +62,29 @@ void WebApiPrometheusClass::onPrometheusMetricsGet(AsyncWebServerRequest* reques
         stream->printf("opendtu_last_update{serial=\"%s\",unit=\"%d\",name=\"%s\"} %d\n",
             serial.c_str(), i, name, inv->Statistics()->getLastUpdate() / 1000);
 
-        // Loop all channels
-        for (auto& t : inv->Statistics()->getChannelTypes()) {
-            for (auto& c : inv->Statistics()->getChannelsByType(t)) {
-                addField(stream, serial, i, inv, t, c, FLD_PAC);
-                addField(stream, serial, i, inv, t, c, FLD_UAC);
-                addField(stream, serial, i, inv, t, c, FLD_IAC);
-                if (t == TYPE_AC) {
-                    addField(stream, serial, i, inv, t, c, FLD_PDC, "PowerDC");
-                } else {
-                    addField(stream, serial, i, inv, t, c, FLD_PDC);
+        // Loop all channels if Statistics have been updated at least once since DTU boot
+        if (inv->Statistics()->getLastUpdate() > 0) {
+            for (auto& t : inv->Statistics()->getChannelTypes()) {
+                for (auto& c : inv->Statistics()->getChannelsByType(t)) {
+                    addField(stream, serial, i, inv, t, c, FLD_PAC);
+                    addField(stream, serial, i, inv, t, c, FLD_UAC);
+                    addField(stream, serial, i, inv, t, c, FLD_IAC);
+                    if (t == TYPE_AC) {
+                        addField(stream, serial, i, inv, t, c, FLD_PDC, "PowerDC");
+                    } else {
+                        addField(stream, serial, i, inv, t, c, FLD_PDC);
+                    }
+                    addField(stream, serial, i, inv, t, c, FLD_UDC);
+                    addField(stream, serial, i, inv, t, c, FLD_IDC);
+                    addField(stream, serial, i, inv, t, c, FLD_YD);
+                    addField(stream, serial, i, inv, t, c, FLD_YT);
+                    addField(stream, serial, i, inv, t, c, FLD_F);
+                    addField(stream, serial, i, inv, t, c, FLD_T);
+                    addField(stream, serial, i, inv, t, c, FLD_PF);
+                    addField(stream, serial, i, inv, t, c, FLD_PRA);
+                    addField(stream, serial, i, inv, t, c, FLD_EFF);
+                    addField(stream, serial, i, inv, t, c, FLD_IRR);
                 }
-                addField(stream, serial, i, inv, t, c, FLD_UDC);
-                addField(stream, serial, i, inv, t, c, FLD_IDC);
-                addField(stream, serial, i, inv, t, c, FLD_YD);
-                addField(stream, serial, i, inv, t, c, FLD_YT);
-                addField(stream, serial, i, inv, t, c, FLD_F);
-                addField(stream, serial, i, inv, t, c, FLD_T);
-                addField(stream, serial, i, inv, t, c, FLD_PF);
-                addField(stream, serial, i, inv, t, c, FLD_PRA);
-                addField(stream, serial, i, inv, t, c, FLD_EFF);
-                addField(stream, serial, i, inv, t, c, FLD_IRR);
             }
         }
     }


### PR DESCRIPTION
This PR does two things

* declare counter-type prometheus metrics as such (yield and eventlog entries are monotonously rising, occasionally resetting to 0)
* after a reboot of the DTU, do not report inverter metrics before first successful read from the inverter

I tested it by rebooting the DTU during daytime, while the inverter was on, and also rebooted the DTU over night.
In both cases, the first few metrics scrapes did not contain any inverter statistics before the very first contact with the inverter. Also, the counter metrics are now declared as such.

This fixes #616.

Rationale: 

## Metric types

Prometheus differentiates between counters and gauges (and others not used here). Quote from https://prometheus.io/docs/concepts/metric_types/ :

> The Prometheus client libraries offer four core metric types. These are currently only differentiated in the client libraries (to enable APIs tailored to the usage of the specific types) and in the wire protocol. The Prometheus server does not yet make use of the type information and flattens all data into untyped time series. This may change in the future.

So, for correctness, the metrics that are counters, should be declared as such.

## Not reporting before successful update

Prior to this change, OpenDTU reported `0` after a reboot, for all metrics that had not yet been updated. This was the case until the first contact with the inverter. If that reboot happens over night, the first contact occurs only hours later, at sunrise, since the inverter shuts down over night. Reporting `0` in counters when it really means "no information" breaks some prometheus functions like [rate()](https://prometheus.io/docs/prometheus/latest/querying/functions/#rate), [increase()](https://prometheus.io/docs/prometheus/latest/querying/functions/#increase), since these consider this a counter reset. If you don't know a value, they should not be reported at all, so the built-in reset-behaviour of these functions works correctly.
Prometheus can handle intervals with no values -- but not intervals with incorrect values. 
Example: 

The daily yield counter is monotonously increasing, but resets every night. So a time series for it might look like

... 200, 201, 221, 0, 20, 25, 40 ...

between 221 and 0, the counter was reset. Using increase(), one can calculate the total yield over the interval, which would be (221-200) + (40-0) = 61. You can also select arbitrary sub-intervals of the time series, with multiple resets.

Note that the Hoymiles inverter does no resets on restarts, e.g. the total yield counter increases eternally. Especially for this counter, reporting 0s inbetween would lead to drastic miscalculations.

... 2000, 2001, 2020, (dtu reboot), 0, 0, 0, (first contact), 2030, 2040, 2050, (dtu reboot), 0, (first contact), 2060, 2070 ...

Using increase() over the total interval, prometheus would return (2020-2000) + (2050-0) + (2070-0) = 4140, when it really should be 2070-2000 = 70.

With this change, the time series looks like this

... 2000, 2001, 2020, (dtu reboot), (no values), (first contact), 2030, 2040, 2050, (dtu reboot), (no values), (first contact), 2060, 2070 ...

and then increase() would calculate 2070-2000 = 70, since there was no reset inbetween.
