### PR TITLE
Add alternative Hardware Settings PIN names

### DIFF
--- a/webapp/src/components/PinInfo.vue
+++ b/webapp/src/components/PinInfo.vue
@@ -23,7 +23,7 @@
                         <td>{{ currentPinAssignment?.nrf24?.mosi }}</td>
                     </tr>
                     <tr>
-                        <td>CLK</td>
+                        <td>CLK {{ $t('pininfo.or') }} SCK</td>
                         <td>{{ selectedPinAssignment?.nrf24?.clk }}</td>
                         <td>{{ currentPinAssignment?.nrf24?.clk }}</td>
                     </tr>
@@ -33,12 +33,12 @@
                         <td>{{ currentPinAssignment?.nrf24?.irq }}</td>
                     </tr>
                     <tr>
-                        <td>EN</td>
+                        <td>EN {{ $t('pininfo.or') }} CE</td>
                         <td>{{ selectedPinAssignment?.nrf24?.en }}</td>
                         <td>{{ currentPinAssignment?.nrf24?.en }}</td>
                     </tr>
                     <tr>
-                        <td>CS</td>
+                        <td>CS  {{ $t('pininfo.or') }} CSN</td>
                         <td>{{ selectedPinAssignment?.nrf24?.cs }}</td>
                         <td>{{ currentPinAssignment?.nrf24?.cs }}</td>
                     </tr>

--- a/webapp/src/locales/de.json
+++ b/webapp/src/locales/de.json
@@ -512,6 +512,7 @@
         "Category": "Kategorie",
         "Name": "Name",
         "ValueSelected": "Ausgewählt",
-        "ValueActive": "Aktiv"
+        "ValueActive": "Aktiv",
+        "or": "oder"
     }
 }

--- a/webapp/src/locales/en.json
+++ b/webapp/src/locales/en.json
@@ -513,6 +513,7 @@
         "Name": "Name",
         "Number": "Number",
         "ValueSelected": "Selected",
-        "ValueActive": "Active"
+        "ValueActive": "Active",
+        "or": "or"
     }
 }

--- a/webapp/src/locales/fr.json
+++ b/webapp/src/locales/fr.json
@@ -512,6 +512,7 @@
         "Category": "Catégorie",
         "Name": "Nom",
         "ValueSelected": "Sélectionné",
-        "ValueActive": "Activé"
+        "ValueActive": "Activé",
+        "or": "ou"
     }
 }


### PR DESCRIPTION
My NRF24+ is labeled like this. 
![image](https://user-images.githubusercontent.com/1101544/221527486-bad023d1-c2fd-4b6a-8887-6c35cc2f2dd2.png)
So I would suggest to add this altenative names to the Web GUI.