### PR TITLE
Add ESP32 S2 support & Lolin S2 mini board layout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 .vscode/settings.json
 platformio-device-monitor*.log
 platformio_override.ini
+.DS_Store

--- a/lib/ResetReason/src/ResetReason.cpp
+++ b/lib/ResetReason/src/ResetReason.cpp
@@ -34,7 +34,7 @@ String ResetReasonClass::get_reset_reason_verbose(uint8_t cpu_id)
     case 3:
         reason_str = F("Software reset digital core");
         break;
-#if !defined(CONFIG_IDF_TARGET_ESP32C3) && !defined(CONFIG_IDF_TARGET_ESP32S3)
+#if !defined(CONFIG_IDF_TARGET_ESP32C3) && !defined(CONFIG_IDF_TARGET_ESP32S3) && !defined(CONFIG_IDF_TARGET_ESP32S2)
     case 4:
         reason_str = F("Legacy watch dog reset digital core");
         break;
@@ -42,7 +42,7 @@ String ResetReasonClass::get_reset_reason_verbose(uint8_t cpu_id)
     case 5:
         reason_str = F("Deep Sleep reset digital core");
         break;
-#if !defined(CONFIG_IDF_TARGET_ESP32C3) && !defined(CONFIG_IDF_TARGET_ESP32S3)
+#if !defined(CONFIG_IDF_TARGET_ESP32C3) && !defined(CONFIG_IDF_TARGET_ESP32S3) && !defined(CONFIG_IDF_TARGET_ESP32S2)
     case 6:
         reason_str = F("Reset by SLC module, reset digital core");
         break;
@@ -68,7 +68,7 @@ String ResetReasonClass::get_reset_reason_verbose(uint8_t cpu_id)
     case 13:
         reason_str = F("RTC Watch dog Reset CPU");
         break;
-#if !defined(CONFIG_IDF_TARGET_ESP32C3) && !defined(CONFIG_IDF_TARGET_ESP32S3)
+#if !defined(CONFIG_IDF_TARGET_ESP32C3) && !defined(CONFIG_IDF_TARGET_ESP32S3) && !defined(CONFIG_IDF_TARGET_ESP32S2)
     case 14:
         reason_str = F("for APP CPU, reset by PRO CPU");
         break;
@@ -100,7 +100,7 @@ String ResetReasonClass::get_reset_reason_short(uint8_t cpu_id)
     case 3:
         reason_str = F("SW_RESET");
         break;
-#if !defined(CONFIG_IDF_TARGET_ESP32C3) && !defined(CONFIG_IDF_TARGET_ESP32S3)
+#if !defined(CONFIG_IDF_TARGET_ESP32C3) && !defined(CONFIG_IDF_TARGET_ESP32S3) && !defined(CONFIG_IDF_TARGET_ESP32S2)
     case 4:
         reason_str = F("OWDT_RESET");
         break;
@@ -108,7 +108,7 @@ String ResetReasonClass::get_reset_reason_short(uint8_t cpu_id)
     case 5:
         reason_str = F("DEEPSLEEP_RESET");
         break;
-#if !defined(CONFIG_IDF_TARGET_ESP32C3) && !defined(CONFIG_IDF_TARGET_ESP32S3)
+#if !defined(CONFIG_IDF_TARGET_ESP32C3) && !defined(CONFIG_IDF_TARGET_ESP32S3) && !defined(CONFIG_IDF_TARGET_ESP32S2)
     case 6:
         reason_str = F("SDIO_RESET");
         break;
@@ -134,7 +134,7 @@ String ResetReasonClass::get_reset_reason_short(uint8_t cpu_id)
     case 13:
         reason_str = F("RTCWDT_CPU_RESET");
         break;
-#if !defined(CONFIG_IDF_TARGET_ESP32C3) && !defined(CONFIG_IDF_TARGET_ESP32S3)
+#if !defined(CONFIG_IDF_TARGET_ESP32C3) && !defined(CONFIG_IDF_TARGET_ESP32S3) && !defined(CONFIG_IDF_TARGET_ESP32S2)
     case 14:
         reason_str = F("EXT_CPU_RESET");
         break;

--- a/platformio.ini
+++ b/platformio.ini
@@ -147,3 +147,13 @@ build_flags = ${env.build_flags}
     -DHOYMILES_PIN_IRQ=16
     -DHOYMILES_PIN_CE=17
     -DHOYMILES_PIN_CS=5
+
+[env:lolin_s2_mini]
+board = lolin_s2_mini
+build_flags = ${env.build_flags}
+    -DHOYMILES_PIN_MISO=13
+    -DHOYMILES_PIN_MOSI=11
+    -DHOYMILES_PIN_SCLK=12
+    -DHOYMILES_PIN_CS=10
+    -DHOYMILES_PIN_IRQ=4
+    -DHOYMILES_PIN_CE=5


### PR DESCRIPTION
This PR allows OpenDTU to run on a ESP32 S2 and adds the Lolin S2 mini as an predefined board with the optimal pinout for S2's according to the [Espressif Docs](https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/api-reference/peripherals/spi_master.html)