### PR TITLE
feat: export panel settings (name, max power, offset) as prometheus metrics

### DIFF
--- a/include/WebApi_prometheus.h
+++ b/include/WebApi_prometheus.h
@@ -15,6 +15,8 @@ private:
 
     void addField(AsyncResponseStream* stream, String& serial, uint8_t idx, std::shared_ptr<InverterAbstract> inv, ChannelType_t type, ChannelNum_t channel, FieldId_t fieldId, const char* channelName = NULL);
 
+    void addPanelInfo(AsyncResponseStream* stream, String& serial, uint8_t idx, std::shared_ptr<InverterAbstract> inv, ChannelType_t type, ChannelNum_t channel);
+
     AsyncWebServer* _server;
 
     enum {


### PR DESCRIPTION
as a followup to #649, this adds configurable panel information (name, maximum power, offset) as prometheus metrics.

The panel name is exported as a constant-1 pseudo-gauge similarly to `opendtu_build` and `opendtu_platform`.

Example: 

```
# HELP opendtu_PanelInfo panel information
# TYPE opendtu_PanelInfo gauge
opendtu_PanelInfo{serial="333333333333",unit="0",name="Garage",channel="0",panelname="Links"} 1
# HELP opendtu_MaxPower panel maximum output power
# TYPE opendtu_MaxPower gauge
opendtu_MaxPower{serial="333333333333",unit="0",name="Garage",channel="0"} 375
# HELP opendtu_YieldTotalOffset panel yield offset (for used inverters)
# TYPE opendtu_YieldTotalOffset gauge
opendtu_YieldTotalOffset{serial="333333333333",unit="0",name="Garage",channel="0"} 0.000000
```