### PR TITLE
NtpAdminView.vue: swap GPS coordinates to Latitude/Longitude

### DIFF
--- a/webapp/src/views/NtpAdminView.vue
+++ b/webapp/src/views/NtpAdminView.vue
@@ -29,13 +29,13 @@
             </CardElement>
 
             <CardElement :text="$t('ntpadmin.LocationConfiguration')" textVariant="text-bg-primary" add-space>
-                <InputElement :label="$t('ntpadmin.Longitude')"
-                              v-model="ntpConfigList.longitude"
-                              type="number" min="-180" max="180" step="any"/>
-
                 <InputElement :label="$t('ntpadmin.Latitude')"
                               v-model="ntpConfigList.latitude"
                               type="number" min="-90" max="90" step="any"/>
+
+                <InputElement :label="$t('ntpadmin.Longitude')"
+                              v-model="ntpConfigList.longitude"
+                              type="number" min="-180" max="180" step="any"/>
             </CardElement>
             <button type="submit" class="btn btn-primary mb-3">{{ $t('ntpadmin.Save') }}</button>
         </form>


### PR DESCRIPTION
In the NTP dialog, the GPS coordinates are shown in an unusual order.
The common way to display GPS coordinates is Latitude+Longitude.
This commit swaps the fields in NtpAdminView.vue, the webapp binaries are not updated.