### PR TITLE
hoymiles: keep backbuffer for StatisticsParser, swap only on success [fixes #727]

### DIFF
--- a/lib/Hoymiles/src/commands/RealTimeRunDataCommand.cpp
+++ b/lib/Hoymiles/src/commands/RealTimeRunDataCommand.cpp
@@ -27,13 +27,19 @@ bool RealTimeRunDataCommand::handleResponse(InverterAbstract* inverter, fragment
 
     // Move all fragments into target buffer
     uint8_t offs = 0;
+
+    // Clear the backbuffer
     inverter->Statistics()->clearBuffer();
     for (uint8_t i = 0; i < max_fragment_id; i++) {
         inverter->Statistics()->appendFragment(offs, fragment[i].fragment, fragment[i].len);
         offs += (fragment[i].len);
     }
-    inverter->Statistics()->resetRxFailureCount();
-    inverter->Statistics()->setLastUpdate(millis());
+
+    // Swaps the backbuffer, if the received statistics fragments match up to the full data size.
+    if (inverter->Statistics()->swap()) {
+        inverter->Statistics()->resetRxFailureCount();
+        inverter->Statistics()->setLastUpdate(millis());
+    }
     return true;
 }
 

--- a/lib/Hoymiles/src/parser/StatisticsParser.cpp
+++ b/lib/Hoymiles/src/parser/StatisticsParser.cpp
@@ -35,8 +35,19 @@ void StatisticsParser::setByteAssignment(const std::list<byteAssign_t>* byteAssi
 
 void StatisticsParser::clearBuffer()
 {
-    memset(_payloadStatistic, 0, STATISTIC_PACKET_SIZE);
+    memset(_payloadStatistic_off, 0, STATISTIC_PACKET_SIZE);
     _statisticLength = 0;
+}
+
+// If the statistics packet has the full size, we swap and confirm that the data is good (return true)
+bool StatisticsParser::swap()
+{
+    if (_statisticLength == STATISTIC_PACKET_SIZE) {
+        memcpy(_payloadStatistic, _payloadStatistic_off, STATISTIC_PACKET_SIZE);
+        return true;
+    }
+
+    return false;
 }
 
 void StatisticsParser::appendFragment(uint8_t offset, uint8_t* payload, uint8_t len)
@@ -45,7 +56,7 @@ void StatisticsParser::appendFragment(uint8_t offset, uint8_t* payload, uint8_t 
         Hoymiles.getMessageOutput()->printf("FATAL: (%s, %d) stats packet too large for buffer\r\n", __FILE__, __LINE__);
         return;
     }
-    memcpy(&_payloadStatistic[offset], payload, len);
+    memcpy(&_payloadStatistic_off[offset], payload, len);
     _statisticLength += len;
 }
 

--- a/lib/Hoymiles/src/parser/StatisticsParser.h
+++ b/lib/Hoymiles/src/parser/StatisticsParser.h
@@ -93,6 +93,7 @@ class StatisticsParser : public Parser {
 public:
     void clearBuffer();
     void appendFragment(uint8_t offset, uint8_t* payload, uint8_t len);
+    bool swap();
 
     void setByteAssignment(const std::list<byteAssign_t>* byteAssignment);
 
@@ -121,6 +122,7 @@ public:
 
 private:
     uint8_t _payloadStatistic[STATISTIC_PACKET_SIZE] = {};
+    uint8_t _payloadStatistic_off[STATISTIC_PACKET_SIZE] = {};
     uint8_t _statisticLength = 0;
     uint16_t _stringMaxPower[CH4];
 


### PR DESCRIPTION
Updates the statistics parser so that only valid statistics packets are "published" (swapped).

Fixes #727