### PR TITLE
Dropdown box fixes when switching UI language

### DIFF
--- a/webapp/src/views/DeviceAdminView.vue
+++ b/webapp/src/views/DeviceAdminView.vue
@@ -27,9 +27,8 @@
                                 <div class="col-sm-10">
                                     <select class="form-select" id="inputPinProfile"
                                         v-model="deviceConfigList.curPin.name">
-                                        <option v-for="device in pinMappingList" :value="device.name"
-                                            :key="device.name">
-                                            {{ device.name }}
+                                        <option v-for="device in pinMappingList" :value="device.name" :key="device.name">
+                                            {{ device.name === "Default" ? $t('deviceadmin.DefaultProfile') : device.name }}
                                         </option>
                                     </select>
                                 </div>
@@ -144,10 +143,8 @@ export default defineComponent({
                     this.pinMappingList = Array<Device>();
                 })
                 .finally(() => {
-                    this.pinMappingList.push({
-                        "name": this.$t('deviceadmin.DefaultProfile')
-                    } as Device);
                     this.pinMappingList.sort((a, b) => (a.name < b.name) ? -1 : 1);
+                    this.pinMappingList.splice(0, 0, { "name": "Default" } as Device);
                     this.pinMappingLoading = false;
                 });
         },

--- a/webapp/src/views/DeviceAdminView.vue
+++ b/webapp/src/views/DeviceAdminView.vue
@@ -63,8 +63,8 @@
                                 </label>
                                 <div class="col-sm-10">
                                     <select class="form-select" v-model="deviceConfigList.display.rotation">
-                                        <option v-for="rotation in displayRotationList" :key="rotation.key" :value="rotation.key">
-                                            {{ rotation.value }}
+                                        <option v-for="(rotation, index) in displayRotationList" :key="index" :value="index">
+                                            {{ $t(`deviceadmin.` + rotation) }}
                                         </option>
                                     </select>
                                 </div>
@@ -119,10 +119,10 @@ export default defineComponent({
             alertType: "info",
             showAlert: false,
             displayRotationList: [
-                { key: 0, value: this.$t('deviceadmin.rot0') },
-                { key: 1, value: this.$t('deviceadmin.rot90') },
-                { key: 2, value: this.$t('deviceadmin.rot180') },
-                { key: 3, value: this.$t('deviceadmin.rot270') },
+                'rot0',
+                'rot90',
+                'rot180',
+                'rot270',
             ],
         }
     },

--- a/webapp/src/views/DtuAdminView.vue
+++ b/webapp/src/views/DtuAdminView.vue
@@ -23,8 +23,8 @@
                     </label>
                     <div class="col-sm-10">
                         <select class="form-select" v-model="dtuConfigList.dtu_palevel">
-                            <option v-for="palevel in palevelList" :key="palevel.key" :value="palevel.key">
-                                {{ palevel.value }}
+                            <option v-for="(palevel, index) in palevelList" :key="index" :value="index">
+                                {{ $t(`dtuadmin.` + palevel) }}
                             </option>
                         </select>
                     </div>
@@ -58,10 +58,10 @@ export default defineComponent({
             dataLoading: true,
             dtuConfigList: {} as DtuConfig,
             palevelList: [
-                { key: 0, value: this.$t('dtuadmin.Min') },
-                { key: 1, value: this.$t('dtuadmin.Low') },
-                { key: 2, value: this.$t('dtuadmin.High') },
-                { key: 3, value: this.$t('dtuadmin.Max') },
+                'Min', 
+                'Low', 
+                'High', 
+                'Max',
             ],
             alertMessage: "",
             alertType: "info",


### PR DESCRIPTION
The content of drop downs isn't relocalized when changing the language in the WebUI. 
This affects drop downs in:

- PA level in _DTU_ admin view
- Display rotation in _Display_ tab of _Hardware_ admin view
- Profile in _Pin mapping_  of _Hardware_ admin view

The last point also fixes the problem, that the localized name of default profile is used for storing the empty pin mapping.
A firmware binary for testing is available for testing in the fork.