### PR TITLE
build: pre-build script for library adjustments

### DIFF
--- a/library_adjustments.py
+++ b/library_adjustments.py
@@ -1,0 +1,50 @@
+import os
+import re
+
+Import("env")
+
+def getLibraryPath(env, libraryPath = None):
+    """Function for retrieving the requested library path for the choosen board in a plain stupid way."""
+    if not libraryPath:
+        raise ValueError('`libraryPath` should not be empty!')
+
+    return os.path.join(env["PROJECT_DIR"], ".pio", "libdeps", env["BOARD"], libraryPath)
+
+def replaceInFile(filePath, text, subs, flags=0):
+    """
+        Function for replacing content for the given file
+        Taken from https://www.studytonight.com/python-howtos/search-and-replace-a-text-in-a-file-in-python
+    """
+    if os.path.exists(filePath):
+        with open(filePath, "r+") as file:
+            #read the file contents
+            file_contents = file.read()
+            text_pattern = re.compile(re.escape(text), flags)
+            file_contents = text_pattern.sub(subs, file_contents)
+            file.seek(0)
+            file.truncate()
+            file.write(file_contents)
+
+def adjustEspAsyncWebServer(env):
+    """Reusable function for replacements within `ESP Async WebServer` library"""
+    libPath = getLibraryPath(env, "ESP Async WebServer")
+    if os.path.exists(libPath):
+        replaceInFile(os.path.join(libPath, "src", "AsyncWebSocket.cpp"), "IPAddress(0U)", "IPAddress((uint32_t)0)")
+
+def adjustSeeedXiaoEsp32c3(env):
+    """Function for replacements required for `seeed_xiao_esp32c3` board"""
+    adjustEspAsyncWebServer(env)
+
+def adjustNothing(env):
+    """Dummy function for doing absolutely nothing :-)"""
+    print ("Nothing to adjust!")
+
+# Replacement lookup table
+# key: boardname as stated in platform.io
+# value: replacement function to be used
+boards = {
+    'seeed_xiao_esp32c3': adjustSeeedXiaoEsp32c3
+}
+
+# Lookup and replace, no entry -> dummy call
+boards.get(env["BOARD"], adjustNothing)(env)

--- a/platformio.ini
+++ b/platformio.ini
@@ -35,6 +35,7 @@ lib_deps =
 
 extra_scripts =
     pre:auto_firmware_version.py
+    pre:library_adjustments.py
 
 board_build.partitions = partitions_custom.csv
 board_build.filesystem = littlefs
@@ -161,3 +162,14 @@ build_flags = ${env.build_flags}
     -DHOYMILES_PIN_CS=10
     -DHOYMILES_PIN_IRQ=4
     -DHOYMILES_PIN_CE=5
+
+[env:seeed_xiao_esp32c3]
+; https://wiki.seeedstudio.com/XIAO_ESP32C3_Getting_Started
+board = seeed_xiao_esp32c3
+build_flags = ${env.build_flags}
+    -DHOYMILES_PIN_MISO=9
+    -DHOYMILES_PIN_MOSI=10
+    -DHOYMILES_PIN_SCLK=8
+    -DHOYMILES_PIN_IRQ=3
+    -DHOYMILES_PIN_CE=4
+    -DHOYMILES_PIN_CS=5


### PR DESCRIPTION
Some hacky stacky extendable extra_scripts stuff included in platform.io allows to modify library code just before a build.

It solves issue #663 and also adds a profile for the _seeed_xiao_esp32c3_ board.
Configuration is taken from issue above and untested since I don't own such a board :-)
