### PR TITLE
use FSPI for esp32-c3

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -60,11 +60,16 @@ build_flags = ${env.build_flags}
 
 
 [env:generic_esp32c3]
-board = esp32dev
-board_build.mcu = esp32c3
+board = esp32-c3-devkitc-02
 custom_patches = esp32c3
 build_flags = ${env.build_flags}
 
+[env:generic_esp32c3_usb]
+board = esp32-c3-devkitc-02
+custom_patches = esp32c3
+build_flags = ${env.build_flags}
+    -DARDUINO_USB_MODE=1
+    -DARDUINO_USB_CDC_ON_BOOT=1
 
 [env:generic_esp32s3]
 board = esp32-s3-devkitc-1

--- a/src/InverterSettings.cpp
+++ b/src/InverterSettings.cpp
@@ -10,11 +10,15 @@
 #include <Hoymiles.h>
 
 // the NRF shall use the second externally usable HW SPI controller
-// for ESP32 that is the so-called VSPI, for ESP32-S2/S3/C3 it is now called implicitly
+// for ESP32 that is the so-called VSPI, for ESP32-S2/S3 it is now called implicitly
 // HSPI, as it has shifted places for these chip generations
 // for all generations, this is equivalent to SPI3_HOST in the lower level driver
-#if CONFIG_IDF_TARGET_ESP32C3 || CONFIG_IDF_TARGET_ESP32S2 || CONFIG_IDF_TARGET_ESP32S3
+// For ESP32-C2, the only externally usable HW SPI controller is SPI2, its signal names
+// being prefixed with FSPI.
+#if  CONFIG_IDF_TARGET_ESP32S2 || CONFIG_IDF_TARGET_ESP32S3
 #define SPI_NRF HSPI
+#elif CONFIG_IDF_TARGET_ESP32C3
+#define SPI_NRF FSPI
 #else
 #define SPI_NRF VSPI
 #endif


### PR DESCRIPTION
SPI on the esp32-c3 did not work for me. With this change it does. This should also fix the problem described on [discussion #735](https://github.com/tbnobody/OpenDTU/discussions/735).

I hope this is the right solution. The SPI names and numbering in the HAL libs is confusing.

Maybe, you would also like to accept the additional section in `platformio.ini`.