### PR TITLE
Device Profile for Wemos Lolin32 OLED

### DIFF
--- a/docs/DeviceProfiles/wemos-lolin32-oled.json
+++ b/docs/DeviceProfiles/wemos-lolin32-oled.json
@@ -1,0 +1,21 @@
+[
+  {
+    "name": "Wemos Lolin32 OLED",
+    "nrf24": {
+      "miso": 2,
+      "mosi": 14,
+      "clk": 12,
+      "irq": 0,
+      "en": 15,
+      "cs": 13
+    },
+    "eth": {
+      "enabled": false
+    },
+    "display": {
+      "type": 2,
+      "data": 5,
+      "clk": 4
+    }
+  }
+]


### PR DESCRIPTION
With the help of [ESP32 Built-in OLED Board (Wemos Lolin32): Pinout, Libraries and OLED Control](https://randomnerdtutorials.com/esp32-built-in-oled-ssd1306/) I found the right pins for the integrated OLED display. For the connection to the NRF24L01+ I've just just the pins directly following each other.

Thank you for this amazing project!