### PR TITLE
Ensure only one PowerCommand and ActivePowerCommand is queued

### DIFF
--- a/lib/Hoymiles/src/inverters/HM_Abstract.cpp
+++ b/lib/Hoymiles/src/inverters/HM_Abstract.cpp
@@ -121,6 +121,10 @@ bool HM_Abstract::sendActivePowerControlRequest(float limit, PowerLimitControlTy
         return false;
     }
 
+    if (CMD_PENDING == SystemConfigPara()->getLastLimitCommandSuccess()) {
+        return false;
+    }
+
     if (type == PowerLimitControlType::RelativNonPersistent || type == PowerLimitControlType::RelativPersistent) {
         limit = min<float>(100, limit);
     }
@@ -144,6 +148,10 @@ bool HM_Abstract::resendActivePowerControlRequest()
 bool HM_Abstract::sendPowerControlRequest(bool turnOn)
 {
     if (!getEnableCommands()) {
+        return false;
+    }
+
+    if (CMD_PENDING == PowerCommand()->getLastPowerCommandSuccess()) {
         return false;
     }
 


### PR DESCRIPTION
Neither a PowerCommand nor an ActivePowerCommand shall be enqueued if another one (of the same type) is already pending.

Adding multiple `PowerCommand`s or `ActivePowerCommand`s is not bad in general, but suppose the following situation:
* An `ActivePowerCommand` was queued and the command state was set to `CMD_PENDING`.
* The radio is busy with the queue, maybe communication is unreliable and it takes some time.
* Another `ActivePowerCommand` is queued and the command state is set to `CMD_PENDING` again.
* The radio finished working on the first `ActivePowerCommand`. The "last command state" is changed to `CMD_OK` or `CMD_NOK`.
* The state is now inconsistent: There is an `ActivePowerCommand` pending, but the "last command state" is *not* `CMD_PENDING`.

This check restricts one of each of the commands per inverter. It seems to me that this is a reasonable limitation.

Another possible solution might be to check the radio queue for other commands of the same type and keeping the `CMD_PENDING` state. This is computationally more expensive, but would make sure that racing commands would all be processed. The current implementation will reject a second command of the same type.