### PR TITLE
Fix: calc expected statistics packet length per parser (#1022/#1084)

### DIFF
--- a/lib/Hoymiles/src/commands/RealTimeRunDataCommand.cpp
+++ b/lib/Hoymiles/src/commands/RealTimeRunDataCommand.cpp
@@ -29,11 +29,11 @@ bool RealTimeRunDataCommand::handleResponse(InverterAbstract* inverter, fragment
     // Check if at least all required bytes are received
     // In case of low power in the inverter it occours that some incomplete fragments
     // with a valid CRC are received.
-    if (getTotalFragmentSize(fragment, max_fragment_id) < inverter->Statistics()->getExpectedByteCount()) {
-        Hoymiles.getMessageOutput()->printf("ERROR in %s: Received fragment size: %d min. expected size: %d\r\n",
-            getCommandName().c_str(),
-            getTotalFragmentSize(fragment, max_fragment_id),
-            inverter->Statistics()->getExpectedByteCount());
+    uint8_t fragmentsSize = getTotalFragmentSize(fragment, max_fragment_id);
+    uint8_t expectedSize = inverter->Statistics()->getExpectedByteCount();
+    if (fragmentsSize < expectedSize) {
+        Hoymiles.getMessageOutput()->printf("ERROR in %s: Received fragment size: %d, min expected size: %d\r\n",
+            getCommandName().c_str(), fragmentsSize, expectedSize);
 
         return false;
     }

--- a/lib/Hoymiles/src/commands/RealTimeRunDataCommand.cpp
+++ b/lib/Hoymiles/src/commands/RealTimeRunDataCommand.cpp
@@ -29,11 +29,11 @@ bool RealTimeRunDataCommand::handleResponse(InverterAbstract* inverter, fragment
     // Check if at least all required bytes are received
     // In case of low power in the inverter it occours that some incomplete fragments
     // with a valid CRC are received.
-    if (getTotalFragmentSize(fragment, max_fragment_id) < inverter->Statistics()->getMaxByteCount()) {
+    if (getTotalFragmentSize(fragment, max_fragment_id) < inverter->Statistics()->getExpectedByteCount()) {
         Hoymiles.getMessageOutput()->printf("ERROR in %s: Received fragment size: %d min. expected size: %d\r\n",
             getCommandName().c_str(),
             getTotalFragmentSize(fragment, max_fragment_id),
-            inverter->Statistics()->getMaxByteCount());
+            inverter->Statistics()->getExpectedByteCount());
 
         return false;
     }

--- a/lib/Hoymiles/src/parser/StatisticsParser.cpp
+++ b/lib/Hoymiles/src/parser/StatisticsParser.cpp
@@ -32,25 +32,18 @@ void StatisticsParser::setByteAssignment(const byteAssign_t* byteAssignment, uin
 {
     _byteAssignment = byteAssignment;
     _byteAssignmentSize = size;
-}
-
-uint8_t StatisticsParser::getMaxByteCount()
-{
-    static uint8_t maxByteCount = 0;
-
-    // Use already calculated value
-    if (maxByteCount > 0) {
-        return maxByteCount;
-    }
 
     for (uint8_t i = 0; i < _byteAssignmentSize; i++) {
         if (_byteAssignment[i].div == CMD_CALC) {
             continue;
         }
-        maxByteCount = max<uint8_t>(maxByteCount, _byteAssignment[i].start + _byteAssignment[i].num);
+        _expectedByteCount = max<uint8_t>(_expectedByteCount, _byteAssignment[i].start + _byteAssignment[i].num);
     }
+}
 
-    return maxByteCount;
+uint8_t StatisticsParser::getExpectedByteCount()
+{
+    return _expectedByteCount;
 }
 
 void StatisticsParser::clearBuffer()

--- a/lib/Hoymiles/src/parser/StatisticsParser.h
+++ b/lib/Hoymiles/src/parser/StatisticsParser.h
@@ -110,7 +110,7 @@ public:
     void setByteAssignment(const byteAssign_t* byteAssignment, uint8_t size);
 
     // Returns 1 based amount of expected bytes of statistic data
-    uint8_t getMaxByteCount();
+    uint8_t getExpectedByteCount();
 
     const byteAssign_t* getAssignmentByChannelField(ChannelType_t type, ChannelNum_t channel, FieldId_t fieldId);
     fieldSettings_t* getSettingByChannelField(ChannelType_t type, ChannelNum_t channel, FieldId_t fieldId);
@@ -142,6 +142,7 @@ private:
 
     const byteAssign_t* _byteAssignment;
     uint8_t _byteAssignmentSize;
+    uint8_t _expectedByteCount;
     std::list<fieldSettings_t> _fieldSettings;
 
     uint32_t _rxFailureCount = 0;


### PR DESCRIPTION
Calculate expected (not max) size on setting the setting the `byteAssignment` only once.