### PR TITLE
Turn LEDs and display off before rebooting.

### DIFF
--- a/include/Display_Graphic.h
+++ b/include/Display_Graphic.h
@@ -19,6 +19,7 @@ public:
     void init(DisplayType_t type, uint8_t data, uint8_t clk, uint8_t cs, uint8_t reset);
     void loop();
     void setContrast(uint8_t contrast);
+    void setPowerSave(uint8_t is_enable);
     void setOrientation(uint8_t rotation = DISPLAY_ROTATION);
     void setLanguage(uint8_t language);
     void setStartupDisplay();

--- a/include/Led_Single.h
+++ b/include/Led_Single.h
@@ -18,6 +18,7 @@ public:
     LedSingleClass();
     void init();
     void loop();
+    void turnAllOff();
 
 private:
     enum class LedState_t {

--- a/src/Display_Graphic.cpp
+++ b/src/Display_Graphic.cpp
@@ -195,4 +195,12 @@ void DisplayGraphicClass::setContrast(uint8_t contrast)
     _display->setContrast(contrast * 2.55f);
 }
 
+void DisplayGraphicClass::setPowerSave(uint8_t is_enable)
+{
+    if (_display_type == DisplayType_t::None) {
+        return;
+    }
+    _display->setPowerSave(is_enable);
+}
+
 DisplayGraphicClass Display;

--- a/src/Led_Single.cpp
+++ b/src/Led_Single.cpp
@@ -93,3 +93,20 @@ void LedSingleClass::loop()
         }
     }
 }
+
+void LedSingleClass::turnAllOff()
+{
+    auto& pin = PinMapping.get();
+
+    for (uint8_t i = 0; i < PINMAPPING_LED_COUNT; i++) {
+        if (pin.led[i] < 0) {
+            continue;
+        }
+        if (_ledState[i] == LedState_t::Off) {
+            continue;
+        }
+
+        _ledState[i] = LedState_t::Off;
+        digitalWrite(pin.led[i], LOW);
+    }
+}

--- a/src/WebApi_config.cpp
+++ b/src/WebApi_config.cpp
@@ -4,6 +4,9 @@
  */
 #include "WebApi_config.h"
 #include "Configuration.h"
+#include "Display_Graphic.h"
+#include "Led_Single.h"
+#include "MessageOutput.h"
 #include "WebApi.h"
 #include "WebApi_errors.h"
 #include <AsyncJson.h>
@@ -114,6 +117,12 @@ void WebApiConfigClass::onConfigDelete(AsyncWebServerRequest* request)
     request->send(response);
 
     LittleFS.remove(CONFIG_FILENAME);
+
+    yield();
+    delay(1000);
+    yield();
+    Display.setPowerSave(true);
+    LedSingle.turnAllOff();
     ESP.restart();
 }
 
@@ -157,9 +166,12 @@ void WebApiConfigClass::onConfigUploadFinish(AsyncWebServerRequest* request)
     response->addHeader("Connection", "close");
     response->addHeader("Access-Control-Allow-Origin", "*");
     request->send(response);
+    MessageOutput.println("New config uploaded. Rebooting...");
     yield();
     delay(1000);
     yield();
+    Display.setPowerSave(true);
+    LedSingle.turnAllOff();
     ESP.restart();
 }
 

--- a/src/WebApi_device.cpp
+++ b/src/WebApi_device.cpp
@@ -5,6 +5,8 @@
 #include "WebApi_device.h"
 #include "Configuration.h"
 #include "Display_Graphic.h"
+#include "Led_Single.h"
+#include "MessageOutput.h"
 #include "PinMapping.h"
 #include "WebApi.h"
 #include "WebApi_errors.h"
@@ -143,6 +145,7 @@ void WebApiDeviceClass::onDeviceAdminPost(AsyncWebServerRequest* request)
         return;
     }
 
+    // A restart must be done if any pinout changed
     CONFIG_T& config = Configuration.get();
     bool performRestart = root["curPin"]["name"].as<String>() != config.Dev_PinMapping;
 
@@ -169,9 +172,12 @@ void WebApiDeviceClass::onDeviceAdminPost(AsyncWebServerRequest* request)
     request->send(response);
 
     if (performRestart) {
+        MessageOutput.println("Pin layout changed. Rebooting...");
         yield();
         delay(1000);
         yield();
+        Display.setPowerSave(true);
+        LedSingle.turnAllOff();
         ESP.restart();
     }
 }

--- a/src/WebApi_firmware.cpp
+++ b/src/WebApi_firmware.cpp
@@ -4,6 +4,8 @@
  */
 #include "WebApi_firmware.h"
 #include "Configuration.h"
+#include "Display_Graphic.h"
+#include "Led_Single.h"
 #include "Update.h"
 #include "WebApi.h"
 #include "helper.h"
@@ -45,6 +47,8 @@ void WebApiFirmwareClass::onFirmwareUpdateFinish(AsyncWebServerRequest* request)
     yield();
     delay(1000);
     yield();
+    Display.setPowerSave(true);
+    LedSingle.turnAllOff();
     ESP.restart();
 }
 

--- a/src/WebApi_maintenance.cpp
+++ b/src/WebApi_maintenance.cpp
@@ -3,6 +3,8 @@
  * Copyright (C) 2022 Thomas Basler and others
  */
 
+#include "Display_Graphic.h"
+#include "Led_Single.h"
 #include "WebApi_maintenance.h"
 #include "WebApi.h"
 #include "WebApi_errors.h"
@@ -78,6 +80,8 @@ void WebApiMaintenanceClass::onRebootPost(AsyncWebServerRequest* request)
         yield();
         delay(1000);
         yield();
+        Display.setPowerSave(true);
+        LedSingle.turnAllOff();
         ESP.restart();
     } else {
         retMsg["message"] = "Reboot cancled!";


### PR DESCRIPTION
If the selected device profile is changed (eg from "LEDs, Display" to "No Output") LEDs and display keeps powered on.
This can also happen if you load a new config.
To prevent this, LEDs and display get powered off before any reboot.


Großen Danke für das tolle Projekt und die ganze Arbeit!  // Many thanks for this great project and the work you did!