### PR TITLE
Execute MQTT client synchronously in main loop()

### DIFF
--- a/include/MqttSettings.h
+++ b/include/MqttSettings.h
@@ -10,6 +10,7 @@ class MqttSettingsClass {
 public:
     MqttSettingsClass();
     void init();
+    void loop();
     void performReconnect();
     bool getConnected();
     void publish(const String& subtopic, const String& payload);

--- a/src/MqttSettings.cpp
+++ b/src/MqttSettings.cpp
@@ -179,15 +179,21 @@ void MqttSettingsClass::init()
     createMqttClientObject();
 }
 
+void MqttSettingsClass::loop()
+{
+    if (nullptr == mqttClient) { return; }
+    mqttClient->loop();
+}
+
 void MqttSettingsClass::createMqttClientObject()
 {
     if (mqttClient != nullptr)
         delete mqttClient;
     const CONFIG_T& config = Configuration.get();
     if (config.Mqtt_Tls) {
-        mqttClient = static_cast<MqttClient*>(new espMqttClientSecure);
+        mqttClient = new espMqttClientSecure(espMqttClientTypes::UseInternalTask::NO);
     } else {
-        mqttClient = static_cast<MqttClient*>(new espMqttClient);
+        mqttClient = new espMqttClient(espMqttClientTypes::UseInternalTask::NO);
     }
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -155,6 +155,8 @@ void loop()
     yield();
     Datastore.loop();
     yield();
+    MqttSettings.loop();
+    yield();
     MqttHandleDtu.loop();
     yield();
     MqttHandleInverter.loop();


### PR DESCRIPTION
processing a published valued on a subscribed topic is currently running in a task that is not the task executing the main `loop()`. that's because the `espMqttClient(Secure)` was constructed without arguments, which selects the constructor with two arguments (priority and core), both of which have default values. that constructor selects `espMqttClientTypes::UseInternalTask::YES`, causing a task to be created in whose context the MQTT client loop is executed, which in turn executes all subscriber callbacks.

MQTT subscribers assume they are running in the same context as the main `loop()`. most code assumes exactly that. as the scheduler is preemptive and very little code is interlocked, we have to make sure to meet the programmer's expectations.

this changeset calls the MQTT client loop in the context of the main `loop()` and enforces the use of `espMqttClientTypes::UseInternalTask::NO`.

this fixes a real-world issue observed by @the-lonely-one in https://github.com/helgeerbe/OpenDTU-OnBattery/issues/268#issuecomment-1657237644: using MQTT, the inverter power limit was set with an interval of ~20 seconds. after at most 15 hours, the inverter would not be sent any limit command any more.

that symptom could be observed due to #1093, which is already merged in the downstream project [OpenDTU-OnBattery](https://github.com/helgeerbe/OpenDTU-OnBattery). the `CMD_PENDING` flag would be set *after* the command was queued and processed, due to preemptive scheduling. since the command is gone, the `CMD_PENDING` flag is never reset.

this change was already tested by me, @helgeerbe, and more importantly by @the-lonely-one, who confirmed that the observed issue is gone with this change.

please note that even if #1093 is never merged (:disappointed:), there is still an issue with the non-thread-safety of this code and other pieces of code:

```
    ActivePowerControlCommand* cmd = _radio->enqueCommand<ActivePowerControlCommand>();
    cmd->setActivePowerLimit(limit, type);
    cmd->setTargetAddress(serial());
    SystemConfigPara()->setLastLimitCommandSuccess(CMD_PENDING);
```

if the scheduler changes contexts right after the first or second line, the second or third line will write freed memory when returning to the context that enqueued the command: the command will be dequeued in another context, rejected as it has no target serial set, and will then be deleted (`shared_ptr` goes out of scope).

it might be beneficial to interlock this and all other public interfaces to the hoymiles library. until then, I consider this changeset an important bugfix. even if the public interface of the hoymiles library is at some point interlocked, I still argue that this changeset is important. as I wrote above: most people assume their code is executed in the context of the main `loop()`, and more problems are to be expected if MQTT subscribers run in a separate context.