### PR TITLE
MessageOutput: thread-safety and dynamic memory

### DIFF
--- a/include/MessageOutput.h
+++ b/include/MessageOutput.h
@@ -2,12 +2,13 @@
 #pragma once
 
 #include <AsyncWebSocket.h>
-#include <HardwareSerial.h>
-#include <Stream.h>
 #include <TaskSchedulerDeclarations.h>
+#include <Print.h>
+#include <freertos/task.h>
 #include <mutex>
-
-#define BUFFER_SIZE 500
+#include <vector>
+#include <unordered_map>
+#include <queue>
 
 class MessageOutputClass : public Print {
 public:
@@ -21,13 +22,19 @@ private:
 
     Task _loopTask;
 
+    using message_t = std::vector<uint8_t>;
+
+    // we keep a buffer for every task and only write complete lines to the
+    // serial output and then move them to be pushed through the websocket.
+    // this way we prevent mangling of messages from different contexts.
+    std::unordered_map<TaskHandle_t, message_t> _task_messages;
+    std::queue<message_t> _lines;
+
     AsyncWebSocket* _ws = nullptr;
-    char _buffer[BUFFER_SIZE];
-    uint16_t _buff_pos = 0;
-    uint32_t _lastSend = 0;
-    bool _forceSend = false;
 
     std::mutex _msgLock;
+
+    void serialWrite(message_t const& m);
 };
 
 extern MessageOutputClass MessageOutput;

--- a/src/MessageOutput.cpp
+++ b/src/MessageOutput.cpp
@@ -2,9 +2,8 @@
 /*
  * Copyright (C) 2022-2023 Thomas Basler and others
  */
+#include <HardwareSerial.h>
 #include "MessageOutput.h"
-
-#include <Arduino.h>
 
 MessageOutputClass MessageOutput;
 
@@ -18,46 +17,97 @@ void MessageOutputClass::init(Scheduler& scheduler)
 
 void MessageOutputClass::register_ws_output(AsyncWebSocket* output)
 {
+    std::lock_guard<std::mutex> lock(_msgLock);
+
     _ws = output;
+}
+
+void MessageOutputClass::serialWrite(MessageOutputClass::message_t const& m)
+{
+    // on ESP32-S3, Serial.flush() blocks until a serial console is attached.
+    // operator bool() of HWCDC returns false if the device is not attached to
+    // a USB host. in general it makes sense to skip writing entirely if the
+    // default serial port is not ready.
+    if (!Serial) { return; }
+
+    size_t written = 0;
+    while (written < m.size()) {
+        written += Serial.write(m.data() + written, m.size() - written);
+    }
+    Serial.flush();
 }
 
 size_t MessageOutputClass::write(uint8_t c)
 {
-    if (_buff_pos < BUFFER_SIZE) {
-        std::lock_guard<std::mutex> lock(_msgLock);
-        _buffer[_buff_pos] = c;
-        _buff_pos++;
-    } else {
-        _forceSend = true;
+    std::lock_guard<std::mutex> lock(_msgLock);
+
+    auto res = _task_messages.emplace(xTaskGetCurrentTaskHandle(), message_t());
+    auto iter = res.first;
+    auto& message = iter->second;
+
+    message.push_back(c);
+
+    if (c == '\n') {
+        serialWrite(message);
+        _lines.emplace(std::move(message));
+        _task_messages.erase(iter);
     }
 
-    return Serial.write(c);
+    return 1;
 }
 
-size_t MessageOutputClass::write(const uint8_t* buffer, size_t size)
+size_t MessageOutputClass::write(const uint8_t *buffer, size_t size)
 {
     std::lock_guard<std::mutex> lock(_msgLock);
-    if (_buff_pos + size < BUFFER_SIZE) {
-        memcpy(&_buffer[_buff_pos], buffer, size);
-        _buff_pos += size;
-    }
-    _forceSend = true;
 
-    return Serial.write(buffer, size);
+    auto res = _task_messages.emplace(xTaskGetCurrentTaskHandle(), message_t());
+    auto iter = res.first;
+    auto& message = iter->second;
+
+    message.reserve(message.size() + size);
+
+    for (size_t idx = 0; idx < size; ++idx) {
+        uint8_t c = buffer[idx];
+
+        message.push_back(c);
+
+        if (c == '\n') {
+            serialWrite(message);
+            _lines.emplace(std::move(message));
+            message.clear();
+            message.reserve(size - idx - 1);
+        }
+    }
+
+    if (message.empty()) { _task_messages.erase(iter); }
+
+    return size;
 }
 
 void MessageOutputClass::loop()
 {
-    // Send data via websocket if either time is over or buffer is full
-    if (_forceSend || (millis() - _lastSend > 1000)) {
-        std::lock_guard<std::mutex> lock(_msgLock);
-        if (_ws && _buff_pos > 0) {
-            _ws->textAll(_buffer, _buff_pos);
-            _buff_pos = 0;
+    std::lock_guard<std::mutex> lock(_msgLock);
+
+    // clean up (possibly filled) buffers of deleted tasks
+    auto map_iter = _task_messages.begin();
+    while (map_iter != _task_messages.end()) {
+        if (eTaskGetState(map_iter->first) == eDeleted) {
+            map_iter = _task_messages.erase(map_iter);
+            continue;
         }
-        if (_forceSend) {
-            _buff_pos = 0;
+
+        ++map_iter;
+    }
+
+    if (!_ws) {
+        while (!_lines.empty()) {
+            _lines.pop(); // do not hog memory
         }
-        _forceSend = false;
+        return;
+    }
+
+    while (!_lines.empty() && _ws->availableForWriteAll()) {
+        _ws->textAll(std::make_shared<message_t>(std::move(_lines.front())));
+        _lines.pop();
     }
 }


### PR DESCRIPTION
Very early on I found issues with the serial output of OpenDTU, i.e., garbled messages, where one message would be interrupted with another message. Also, some output seemed to be missing. There was at least discussion about this, see #1130. Very recently, a change was implemented in 43cba675310e0cfda3e325092aed6555a370ed48, which is a big step forward, but does not solve all issues:

* The MessageOutput buffer for the web console is still limited to an arbitrary amount of 500 Bytes.
* Lots of functions defined in the core's `Print.h` and implemented in `Print.cpp`, especially `println(String&)`, still are "vurnerable" to scheduling. Example: Scheduling can happen after printing the contents of a line, but before printing the `\r\n`.
* Not all messages are printed using `println()`, but are stitched together with multiple `print()`s. Those can still be garbled beyond recognition due to scheduling.
* Minor issue: There is a small chance of a buffer overflow in `MessageOutput::write(uint8_t)` because the lock is not protecting the buffer position check.

My proposal with this MR is as follows:
* Every task/context writes to its own buffer (managed by MessageOutput). This prevents messages being garbled at all.
* These buffers are dynamic, such that there is no issue printing lots of text per line.
* Each time a line is completed, and only then, the task's buffered message is printed on the serial console. Additionally, the whole line is moved to a line-buffer for transport to the websocket.
* In the context of the main loop, the buffered lines are moved to the websocket. It is taken care that the websocket queue is not overrun, so all messages actually appear in the web console.
* The line buffer for the web console within MessageOutput is dynamic, such that no text has to be dropped (RAM limits still apply, of course). Lines are retried once the websocket handler got to process its queue.
* It is taken care that memory that can be freed is freed. Also, buffers of deleted tasks are freed in each loop.