### PR TITLE
Add option to use new Home Assistant entity naming scheme

### DIFF
--- a/include/Configuration.h
+++ b/include/Configuration.h
@@ -87,6 +87,7 @@ struct CONFIG_T {
     char Mqtt_Hass_Topic[MQTT_MAX_TOPIC_STRLEN + 1];
     bool Mqtt_Hass_IndividualPanels;
     bool Mqtt_Hass_Expire;
+    bool Mqtt_Hass_LegacyNames;
 
     bool Mqtt_Tls;
     char Mqtt_RootCaCert[MQTT_MAX_CERT_STRLEN + 1];

--- a/include/MqttHandleHass.h
+++ b/include/MqttHandleHass.h
@@ -62,6 +62,7 @@ private:
     void publishInverterNumber(std::shared_ptr<InverterAbstract> inv, const char* caption, const char* icon, const char* category, const char* commandTopic, const char* stateTopic, const char* unitOfMeasure, int16_t min = 1, int16_t max = 100);
     void publishInverterBinarySensor(std::shared_ptr<InverterAbstract> inv, const char* caption, const char* subTopic, const char* payload_on, const char* payload_off);
     void createDeviceInfo(JsonObject& object, std::shared_ptr<InverterAbstract> inv);
+    String getEntityPrefix(std::shared_ptr<InverterAbstract> inv);
 
     bool _wasConnected = false;
     bool _updateForced = false;

--- a/include/defaults.h
+++ b/include/defaults.h
@@ -86,6 +86,7 @@
 #define MQTT_HASS_RETAIN true
 #define MQTT_HASS_TOPIC "homeassistant/"
 #define MQTT_HASS_INDIVIDUALPANELS false
+#define MQTT_HASS_LEGACYNAMES true
 
 #define DEV_PINMAPPING ""
 

--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -77,6 +77,7 @@ bool ConfigurationClass::write()
     mqtt_hass["topic"] = config.Mqtt_Hass_Topic;
     mqtt_hass["individual_panels"] = config.Mqtt_Hass_IndividualPanels;
     mqtt_hass["expire"] = config.Mqtt_Hass_Expire;
+    mqtt_hass["legacy_names"] = config.Mqtt_Hass_LegacyNames;
 
     JsonObject dtu = doc.createNestedObject("dtu");
     dtu["serial"] = config.Dtu_Serial;
@@ -223,6 +224,7 @@ bool ConfigurationClass::read()
     config.Mqtt_Hass_Expire = mqtt_hass["expire"] | MQTT_HASS_EXPIRE;
     config.Mqtt_Hass_IndividualPanels = mqtt_hass["individual_panels"] | MQTT_HASS_INDIVIDUALPANELS;
     strlcpy(config.Mqtt_Hass_Topic, mqtt_hass["topic"] | MQTT_HASS_TOPIC, sizeof(config.Mqtt_Hass_Topic));
+    config.Mqtt_Hass_LegacyNames = mqtt_hass["legacy_names"] | MQTT_HASS_LEGACYNAMES;
 
     JsonObject dtu = doc["dtu"];
     config.Dtu_Serial = dtu["serial"] | DTU_SERIAL;

--- a/src/MqttHandleHass.cpp
+++ b/src/MqttHandleHass.cpp
@@ -115,9 +115,9 @@ void MqttHandleHassClass::publishField(std::shared_ptr<InverterAbstract> inv, Ch
 
         String name;
         if (type != TYPE_DC) {
-            name = String(inv->name()) + " " + fieldName;
+            name = getEntityPrefix(inv) + fieldName;
         } else {
-            name = String(inv->name()) + " CH" + chanNum + " " + fieldName;
+            name = getEntityPrefix(inv) + "CH" + chanNum + " " + fieldName;
         }
 
         DynamicJsonDocument root(1024);
@@ -166,7 +166,7 @@ void MqttHandleHassClass::publishInverterButton(std::shared_ptr<InverterAbstract
     String cmdTopic = MqttSettings.getPrefix() + serial + "/" + subTopic;
 
     DynamicJsonDocument root(1024);
-    root["name"] = String(inv->name()) + " " + caption;
+    root["name"] = getEntityPrefix(inv) + caption;
     root["uniq_id"] = serial + "_" + buttonId;
     if (strcmp(icon, "")) {
         root["ic"] = icon;
@@ -205,7 +205,7 @@ void MqttHandleHassClass::publishInverterNumber(
     String statTopic = MqttSettings.getPrefix() + serial + "/" + stateTopic;
 
     DynamicJsonDocument root(1024);
-    root["name"] = String(inv->name()) + " " + caption;
+    root["name"] = getEntityPrefix(inv) + caption;
     root["uniq_id"] = serial + "_" + buttonId;
     if (strcmp(icon, "")) {
         root["ic"] = icon;
@@ -240,7 +240,7 @@ void MqttHandleHassClass::publishInverterBinarySensor(std::shared_ptr<InverterAb
     String statTopic = MqttSettings.getPrefix() + serial + "/" + subTopic;
 
     DynamicJsonDocument root(1024);
-    root["name"] = String(inv->name()) + " " + caption;
+    root["name"] = getEntityPrefix(inv) + caption;
     root["uniq_id"] = serial + "_" + sensorId;
     root["stat_t"] = statTopic;
     root["pl_on"] = payload_on;
@@ -262,6 +262,14 @@ void MqttHandleHassClass::createDeviceInfo(JsonObject& object, std::shared_ptr<I
     object["mf"] = "OpenDTU";
     object["mdl"] = inv->typeName();
     object["sw"] = AUTO_GIT_HASH;
+}
+
+String MqttHandleHassClass::getEntityPrefix(std::shared_ptr<InverterAbstract> inv)
+{
+    if (Configuration.get().Mqtt_Hass_LegacyNames) {
+        return String(inv->name()) + " ";
+    }
+    return String();
 }
 
 void MqttHandleHassClass::publish(const String& subtopic, const String& payload)

--- a/src/WebApi_mqtt.cpp
+++ b/src/WebApi_mqtt.cpp
@@ -54,6 +54,7 @@ void WebApiMqttClass::onMqttStatus(AsyncWebServerRequest* request)
     root["mqtt_hass_retain"] = config.Mqtt_Hass_Retain;
     root["mqtt_hass_topic"] = config.Mqtt_Hass_Topic;
     root["mqtt_hass_individualpanels"] = config.Mqtt_Hass_IndividualPanels;
+    root["mqtt_hass_legacy_names"] = config.Mqtt_Hass_LegacyNames;
 
     response->setLength();
     request->send(response);
@@ -90,6 +91,7 @@ void WebApiMqttClass::onMqttAdminGet(AsyncWebServerRequest* request)
     root["mqtt_hass_retain"] = config.Mqtt_Hass_Retain;
     root["mqtt_hass_topic"] = config.Mqtt_Hass_Topic;
     root["mqtt_hass_individualpanels"] = config.Mqtt_Hass_IndividualPanels;
+    root["mqtt_hass_legacy_names"] = config.Mqtt_Hass_LegacyNames;
 
     response->setLength();
     request->send(response);
@@ -153,7 +155,8 @@ void WebApiMqttClass::onMqttAdminPost(AsyncWebServerRequest* request)
             && root.containsKey("mqtt_hass_expire")
             && root.containsKey("mqtt_hass_retain")
             && root.containsKey("mqtt_hass_topic")
-            && root.containsKey("mqtt_hass_individualpanels"))) {
+            && root.containsKey("mqtt_hass_individualpanels")
+            && root.containsKey("mqtt_hass_legacy_names"))) {
         retMsg["message"] = "Values are missing!";
         retMsg["code"] = WebApiError::GenericValueMissing;
         response->setLength();
@@ -318,6 +321,7 @@ void WebApiMqttClass::onMqttAdminPost(AsyncWebServerRequest* request)
     config.Mqtt_Hass_Retain = root["mqtt_hass_retain"].as<bool>();
     config.Mqtt_Hass_IndividualPanels = root["mqtt_hass_individualpanels"].as<bool>();
     strlcpy(config.Mqtt_Hass_Topic, root["mqtt_hass_topic"].as<String>().c_str(), sizeof(config.Mqtt_Hass_Topic));
+    config.Mqtt_Hass_LegacyNames = root["mqtt_hass_legacy_names"].as<bool>();
     Configuration.write();
 
     retMsg["type"] = "success";

--- a/webapp/src/locales/de.json
+++ b/webapp/src/locales/de.json
@@ -273,6 +273,7 @@
         "HassSummary": "Home Assistant MQTT-Auto-Discovery Konfigurationszusammenfassung",
         "Expire": "Ablaufen",
         "IndividualPanels": "Einzelne Paneele",
+        "LegacyNames": "Altes Namensschema",
         "RuntimeSummary": "Laufzeitzusammenfassung",
         "ConnectionStatus": "Verbindungsstatus",
         "Connected": "verbunden",
@@ -431,6 +432,7 @@
         "HassRetain": "Retain Flag aktivieren",
         "HassExpire": "Ablauffunktion aktivieren",
         "HassIndividual": "Einzelne Paneele",
+        "HassLegacyNames": "Altes Namensschema",
         "Save": "@:dtuadmin.Save"
     },
     "inverteradmin": {

--- a/webapp/src/locales/en.json
+++ b/webapp/src/locales/en.json
@@ -273,6 +273,7 @@
         "HassSummary": "Home Assistant MQTT Auto Discovery Configuration Summary",
         "Expire": "Expire",
         "IndividualPanels": "Individual Panels",
+        "LegacyNames": "Legacy Naming Scheme",
         "RuntimeSummary": "Runtime Summary",
         "ConnectionStatus": "Connection Status",
         "Connected": "connected",
@@ -431,6 +432,7 @@
         "HassRetain": "Enable Retain Flag",
         "HassExpire": "Enable Expiration",
         "HassIndividual": "Individual Panels",
+        "HassLegacyNames": "Legacy Naming Scheme",
         "Save": "@:dtuadmin.Save"
     },
     "inverteradmin": {

--- a/webapp/src/locales/fr.json
+++ b/webapp/src/locales/fr.json
@@ -273,6 +273,7 @@
         "HassSummary": "Résumé de la configuration de la découverte automatique du MQTT de Home Assistant",
         "Expire": "Expiration",
         "IndividualPanels": "Panneaux individuels",
+        "LegacyNames": "Ancien schéma de nommage",
         "RuntimeSummary": "Résumé du temps de fonctionnement",
         "ConnectionStatus": "État de la connexion",
         "Connected": "connecté",
@@ -431,6 +432,7 @@
         "HassRetain": "Activer du maintien",
         "HassExpire": "Activer l'expiration",
         "HassIndividual": "Panneaux individuels",
+        "HassLegacyNames": "Ancien schéma de nommage",
         "Save": "@:dtuadmin.Save"
     },
     "inverteradmin": {

--- a/webapp/src/types/MqttConfig.ts
+++ b/webapp/src/types/MqttConfig.ts
@@ -20,4 +20,5 @@ export interface MqttConfig {
     mqtt_hass_retain: boolean;
     mqtt_hass_topic: string;
     mqtt_hass_individualpanels: boolean;
+    mqtt_hass_legacy_names: boolean;
 }

--- a/webapp/src/types/MqttStatus.ts
+++ b/webapp/src/types/MqttStatus.ts
@@ -16,4 +16,5 @@ export interface MqttStatus {
     mqtt_hass_retain: boolean;
     mqtt_hass_topic: string;
     mqtt_hass_individualpanels: boolean;
+    mqtt_hass_legacy_names: boolean;
 }

--- a/webapp/src/views/MqttAdminView.vue
+++ b/webapp/src/views/MqttAdminView.vue
@@ -113,8 +113,12 @@
                               type="checkbox"/>
 
                 <InputElement :label="$t('mqttadmin.HassIndividual')"
-                              v-model="mqttConfigList.mqtt_hass_individualpanels"
-                              type="checkbox"/>
+                            v-model="mqttConfigList.mqtt_hass_individualpanels"
+                            type="checkbox"/>
+
+                <InputElement :label="$t('mqttadmin.HassLegacyNames')"
+                            v-model="mqttConfigList.mqtt_hass_legacy_names"
+                            type="checkbox"/>
             </CardElement>
 
             <button type="submit" class="btn btn-primary mb-3">{{ $t('mqttadmin.Save') }}</button>

--- a/webapp/src/views/MqttInfoView.vue
+++ b/webapp/src/views/MqttInfoView.vue
@@ -93,6 +93,12 @@
                                 <StatusBadge :status="mqttDataList.mqtt_hass_individualpanels" true_text="mqttinfo.Enabled" false_text="mqttinfo.Disabled" />
                             </td>
                         </tr>
+                        <tr>
+                            <th>{{ $t('mqttinfo.LegacyNames') }}</th>
+                            <td>
+                                <StatusBadge :status="mqttDataList.mqtt_hass_legacy_names" true_text="mqttinfo.Enabled" false_text="mqttinfo.Disabled" />
+                            </td>
+                        </tr>
                     </tbody>
                 </table>
             </div>


### PR DESCRIPTION
Handle issue #1194 by adding an option to switch between the old and new naming scheme under MQTT settings.

Rebuilding the webapp is required, but a new build has intentionally not been committed yet to avoid merge conflicts.