### PR TITLE
make vite proxy target easily configurable

### DIFF
--- a/webapp/.gitignore
+++ b/webapp/.gitignore
@@ -13,6 +13,7 @@ dist
 dist-ssr
 coverage
 *.local
+vite.user.ts
 
 /cypress/videos/
 /cypress/screenshots/

--- a/webapp/vite.config.ts
+++ b/webapp/vite.config.ts
@@ -9,6 +9,14 @@ import VueI18nPlugin from '@intlify/unplugin-vue-i18n/vite'
 
 const path = require('path')
 
+// example 'vite.user.ts': export const proxy_target = '192.168.16.107'
+let proxy_target;
+try {
+    proxy_target = require('./vite.user.ts').proxy_target;
+} catch (error) {
+    proxy_target = '192.168.178.87';
+}
+
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [
@@ -52,15 +60,15 @@ export default defineConfig({
   server: {
     proxy: {
       '^/api': {
-        target: 'http://192.168.20.110/'
+        target: 'http://' + proxy_target
       },
       '^/livedata': {
-        target: 'ws://192.168.20.110/',
+        target: 'ws://' + proxy_target,
         ws: true,
         changeOrigin: true
       },
       '^/console': {
-        target: 'ws://192.168.20.110/',
+        target: 'ws://' + proxy_target,
         ws: true,
         changeOrigin: true
       }


### PR DESCRIPTION
the current proxy target IP address is probably only working for a single developer at a time. this change introduces a vite.user.ts, which is ingored by GIT, and which can define a proxy_target that works for the respective developer.

this does not change the default behavior, as the fallback value is still the old IP address. if the new vite.user.ts file does not exist, or if it does not export proxy_target, the fallback value is used.

file vite.config.ts adds an example in a comment of how to bootstrap a vite.user.ts.