### PR TITLE
Fix #1250: Implement offset cache for "YieldDay"

### DIFF
--- a/lib/Hoymiles/src/parser/StatisticsParser.cpp
+++ b/lib/Hoymiles/src/parser/StatisticsParser.cpp
@@ -281,11 +281,13 @@ static bool isMidnight()
     time(&raw);
     localtime_r(&raw, &info);
 
-    if (!info.tm_hour && !reminder) {
-        // midnight detected
-        if (info.tm_min > 1)
-            reminder = true;
-        return true;
+    if (!info.tm_hour) {
+        if (!reminder) {
+            // midnight detected
+            if (info.tm_min > 1)
+                reminder = true;
+            return true;
+        }
     } else
         reminder = false;
 

--- a/lib/Hoymiles/src/parser/StatisticsParser.cpp
+++ b/lib/Hoymiles/src/parser/StatisticsParser.cpp
@@ -258,22 +258,24 @@ float StatisticsParser::updateCurrentYieldDay(float yield)
 {
     int wd = getWeekDay();
 
-    if (-1 == _laskWeekDay)
-        _laskWeekDay = wd;
-    else
-        if (wd != _laskWeekDay) {
+    if (-1 == _lastWeekDay) {
+        _lastWeekDay = wd;
+    } else {
+        if (wd != _lastWeekDay) {
             // new day detected, reset counters
             _YieldDayCh0Offset = 0;
             _lastYieldDayCh0 = 0;
 
-            _laskWeekDay = wd;
+            _lastWeekDay = wd;
         }
+    }
 
     if (!yield) {
         _YieldDayCh0Offset += _lastYieldDayCh0;
         _lastYieldDayCh0 = 0;
-    } else
+    } else {
         _lastYieldDayCh0 = yield;
+    }
 
     return _YieldDayCh0Offset + yield;
 }

--- a/lib/Hoymiles/src/parser/StatisticsParser.cpp
+++ b/lib/Hoymiles/src/parser/StatisticsParser.cpp
@@ -254,22 +254,6 @@ uint32_t StatisticsParser::getRxFailureCount()
     return _rxFailureCount;
 }
 
-float StatisticsParser::updateCurrentYieldTotal(float yield)
-{
-    if (isMidnight()) {
-        _YieldTotalCh0Offset = 0;
-        _lastYieldTotalCh0 = 0;
-    }
-
-    if (!yield) {
-        _YieldTotalCh0Offset += _lastYieldTotalCh0;
-        _lastYieldTotalCh0 = 0;
-    } else
-        _lastYieldTotalCh0 = yield;
-
-    return _YieldTotalCh0Offset + yield;
-}
-
 float StatisticsParser::updateCurrentYieldDay(float yield)
 {
     if (isMidnight()) {
@@ -314,7 +298,7 @@ static float calcYieldTotalCh0(StatisticsParser* iv, uint8_t arg0)
     for (auto& channel : iv->getChannelsByType(TYPE_DC)) {
         yield += iv->getChannelFieldValue(TYPE_DC, channel, FLD_YT);
     }
-    return iv->updateCurrentYieldTotal(yield);
+    return yield;
 }
 
 static float calcYieldDayCh0(StatisticsParser* iv, uint8_t arg0)

--- a/lib/Hoymiles/src/parser/StatisticsParser.cpp
+++ b/lib/Hoymiles/src/parser/StatisticsParser.cpp
@@ -277,13 +277,13 @@ static bool isMidnight()
     static bool reminder = false;
 
     time_t raw;
-    struct tm *info;
+    struct tm info;
     time(&raw);
-    info = localtime(&raw);
+    localtime_r(&raw, &info);
 
-    if (!info->tm_hour && !reminder) {
+    if (!info.tm_hour && !reminder) {
         // midnight detected
-        if (info->tm_min > 1)
+        if (info.tm_min > 1)
             reminder = true;
         return true;
     } else

--- a/lib/Hoymiles/src/parser/StatisticsParser.h
+++ b/lib/Hoymiles/src/parser/StatisticsParser.h
@@ -155,6 +155,7 @@ private:
 
     float _YieldDayCh0Offset = 0;
     float _lastYieldDayCh0 = 0;
+    int _laskWeekDay = -1;
 
     SemaphoreHandle_t _xSemaphore;
 };

--- a/lib/Hoymiles/src/parser/StatisticsParser.h
+++ b/lib/Hoymiles/src/parser/StatisticsParser.h
@@ -139,7 +139,6 @@ public:
     void incrementRxFailureCount();
     uint32_t getRxFailureCount();
 
-    float updateCurrentYieldTotal(float yield);
     float updateCurrentYieldDay(float yield);
 
 private:
@@ -154,9 +153,7 @@ private:
 
     uint32_t _rxFailureCount = 0;
 
-    float _YieldTotalCh0Offset = 0;
     float _YieldDayCh0Offset = 0;
-    float _lastYieldTotalCh0 = 0;
     float _lastYieldDayCh0 = 0;
 
     SemaphoreHandle_t _xSemaphore;

--- a/lib/Hoymiles/src/parser/StatisticsParser.h
+++ b/lib/Hoymiles/src/parser/StatisticsParser.h
@@ -155,7 +155,7 @@ private:
 
     float _YieldDayCh0Offset = 0;
     float _lastYieldDayCh0 = 0;
-    int _laskWeekDay = -1;
+    int _lastWeekDay = -1;
 
     SemaphoreHandle_t _xSemaphore;
 };

--- a/lib/Hoymiles/src/parser/StatisticsParser.h
+++ b/lib/Hoymiles/src/parser/StatisticsParser.h
@@ -139,6 +139,9 @@ public:
     void incrementRxFailureCount();
     uint32_t getRxFailureCount();
 
+    float updateCurrentYieldTotal(float yield);
+    float updateCurrentYieldDay(float yield);
+
 private:
     uint8_t _payloadStatistic[STATISTIC_PACKET_SIZE] = {};
     uint8_t _statisticLength = 0;
@@ -150,6 +153,11 @@ private:
     std::list<fieldSettings_t> _fieldSettings;
 
     uint32_t _rxFailureCount = 0;
+
+    float _YieldTotalCh0Offset = 0;
+    float _YieldDayCh0Offset = 0;
+    float _lastYieldTotalCh0 = 0;
+    float _lastYieldDayCh0 = 0;
 
     SemaphoreHandle_t _xSemaphore;
 };


### PR DESCRIPTION
This proposed fix works around an issue caused by an inverter restart (by purpose or due to light conditions).
YieldDay is volatile and needs to be cached. This is to have a consistent display of total day yield both in live view and MQTT.
The cached values are reset at midnight.
