### PR TITLE
Fix: Home Assistant autoconf change inverter limits

### DIFF
--- a/include/MqttHandleHass.h
+++ b/include/MqttHandleHass.h
@@ -59,7 +59,7 @@ private:
     void publish(const String& subtopic, const String& payload);
     void publishField(std::shared_ptr<InverterAbstract> inv, ChannelType_t type, ChannelNum_t channel, byteAssign_fieldDeviceClass_t fieldType, bool clear = false);
     void publishInverterButton(std::shared_ptr<InverterAbstract> inv, const char* caption, const char* icon, const char* category, const char* deviceClass, const char* subTopic, const char* payload);
-    void publishInverterNumber(std::shared_ptr<InverterAbstract> inv, const char* caption, const char* icon, const char* category, const char* commandTopic, const char* stateTopic, const char* unitOfMeasure, int16_t min = 1, int16_t max = 100);
+    void publishInverterNumber(std::shared_ptr<InverterAbstract> inv, const char* caption, const char* icon, const char* category, const char* commandTopic, const char* stateTopic, const char* unitOfMeasure, int16_t min = 0, int16_t max = 100);
     void publishInverterBinarySensor(std::shared_ptr<InverterAbstract> inv, const char* caption, const char* subTopic, const char* payload_on, const char* payload_off);
     void createDeviceInfo(JsonObject& object, std::shared_ptr<InverterAbstract> inv);
 

--- a/src/MqttHandleHass.cpp
+++ b/src/MqttHandleHass.cpp
@@ -58,8 +58,8 @@ void MqttHandleHassClass::publishConfig()
         publishInverterNumber(inv, "Limit NonPersistent Relative", "mdi:speedometer", "config", "cmd/limit_nonpersistent_relative", "status/limit_relative", "%");
         publishInverterNumber(inv, "Limit Persistent Relative", "mdi:speedometer", "config", "cmd/limit_persistent_relative", "status/limit_relative", "%");
 
-        publishInverterNumber(inv, "Limit NonPersistent Absolute", "mdi:speedometer", "config", "cmd/limit_nonpersistent_absolute", "status/limit_absolute", "W", 10, 2250);
-        publishInverterNumber(inv, "Limit Persistent Absolute", "mdi:speedometer", "config", "cmd/limit_persistent_absolute", "status/limit_absolute", "W", 10, 2250);
+        publishInverterNumber(inv, "Limit NonPersistent Absolute", "mdi:speedometer", "config", "cmd/limit_nonpersistent_absolute", "status/limit_absolute", "W", 0, 2250);
+        publishInverterNumber(inv, "Limit Persistent Absolute", "mdi:speedometer", "config", "cmd/limit_persistent_absolute", "status/limit_absolute", "W", 0, 2250);
 
         publishInverterBinarySensor(inv, "Reachable", "status/reachable", "1", "0");
         publishInverterBinarySensor(inv, "Producing", "status/producing", "1", "0");


### PR DESCRIPTION
The announced limits for inverters in HA autoconfig messages are not suitable for the sub-project OpenDTU-onBattery. Error messages found in HA logs are

Invalid value for number.limit_persistent_relative: 0.1 (range 1.0 - 100.0)
Invalid value for number.limit_nonpersistent_absolute: 0.6 (range 10.0 - 2250.0)
Invalid value for number.limit_persistent_absolute: 0.6 (range 10.0 - 2250.0)
Invalid value for number.limit_nonpersistent_absolute: 9.6 (range 10.0 - 2250.0)
Invalid value for number.limit_persistent_absolute: 9.6 (range 10.0 - 2250.0)

This fix changes the limit minimum to 0 (zero) instead of 1 or 10.