### PR TITLE
Added pin profile where the nrf24 module can be soldered directly.

### DIFF
--- a/docs/DeviceProfiles/lilygo_ttgo_t-internet_poe.json
+++ b/docs/DeviceProfiles/lilygo_ttgo_t-internet_poe.json
@@ -18,5 +18,50 @@
             "type": 0,
             "clk_mode": 3
         }
+    },
+    {
+        "name": "LILYGO TTGO T-Internet-POE, nrf24 direct solder",
+        "nrf24": {
+            "miso": 12,
+            "mosi": 4,
+            "clk": 15,
+            "irq": 33,
+            "en": 14,
+            "cs": 2
+        },
+        "eth": {
+            "enabled": true,
+            "phy_addr": 0,
+            "power": -1,
+            "mdc": 23,
+            "mdio": 18,
+            "type": 0,
+            "clk_mode": 3
+        }
+    },
+    {
+        "name": "LILYGO TTGO T-Internet-POE, nrf24 direct solder, SSD1306",
+        "nrf24": {
+            "miso": 12,
+            "mosi": 4,
+            "clk": 15,
+            "irq": 33,
+            "en": 14,
+            "cs": 2
+        },
+        "eth": {
+            "enabled": true,
+            "phy_addr": 0,
+            "power": -1,
+            "mdc": 23,
+            "mdio": 18,
+            "type": 0,
+            "clk_mode": 3
+        },
+        "display": {
+            "type": 2,
+            "data": 16,
+            "clk": 32
+        }
     }
 ]


### PR DESCRIPTION
This PR adds a pin profile where the nrf24+ can be soldered directly onto the pcb of the lilygo ttgo internet poe board.

Also added a profile with a SSD1306.

Here is a picture of where the components can be soldered.
![T-Internet-POE-Lilygo_5 pin](https://github.com/tbnobody/OpenDTU/assets/1113780/05f822b2-f151-4b31-b649-c30655d6054e)
