### PR TITLE
feat(home assistant): add dtu device & sensors

### DIFF
--- a/include/MqttHandleHass.h
+++ b/include/MqttHandleHass.h
@@ -57,10 +57,12 @@ public:
 
 private:
     void publish(const String& subtopic, const String& payload);
+    void publishDTUSensor(const char* name, const char* device_class, const char* category, const char* icon, const char* unit_of_measure, const char* subTopic);
     void publishField(std::shared_ptr<InverterAbstract> inv, ChannelType_t type, ChannelNum_t channel, byteAssign_fieldDeviceClass_t fieldType, bool clear = false);
     void publishInverterButton(std::shared_ptr<InverterAbstract> inv, const char* caption, const char* icon, const char* category, const char* deviceClass, const char* subTopic, const char* payload);
     void publishInverterNumber(std::shared_ptr<InverterAbstract> inv, const char* caption, const char* icon, const char* category, const char* commandTopic, const char* stateTopic, const char* unitOfMeasure, int16_t min = 1, int16_t max = 100);
     void publishInverterBinarySensor(std::shared_ptr<InverterAbstract> inv, const char* caption, const char* subTopic, const char* payload_on, const char* payload_off);
+    void createDTUDeviceInfo(JsonObject& object);
     void createDeviceInfo(JsonObject& object, std::shared_ptr<InverterAbstract> inv);
 
     bool _wasConnected = false;

--- a/include/MqttHandleHass.h
+++ b/include/MqttHandleHass.h
@@ -58,6 +58,7 @@ public:
 private:
     void publish(const String& subtopic, const String& payload);
     void publishDTUSensor(const char* name, const char* device_class, const char* category, const char* icon, const char* unit_of_measure, const char* subTopic);
+    void publishDTUBinarySensor(const char* name, const char* device_class, const char* category, const char* payload_on, const char* payload_off);
     void publishField(std::shared_ptr<InverterAbstract> inv, ChannelType_t type, ChannelNum_t channel, byteAssign_fieldDeviceClass_t fieldType, bool clear = false);
     void publishInverterButton(std::shared_ptr<InverterAbstract> inv, const char* caption, const char* icon, const char* category, const char* deviceClass, const char* subTopic, const char* payload);
     void publishInverterNumber(std::shared_ptr<InverterAbstract> inv, const char* caption, const char* icon, const char* category, const char* commandTopic, const char* stateTopic, const char* unitOfMeasure, int16_t min = 1, int16_t max = 100);

--- a/src/MqttHandleHass.cpp
+++ b/src/MqttHandleHass.cpp
@@ -313,6 +313,7 @@ void MqttHandleHassClass::createDeviceInfo(JsonObject& object, std::shared_ptr<I
     object["mf"] = "OpenDTU";
     object["mdl"] = inv->typeName();
     object["sw"] = AUTO_GIT_HASH;
+    object["via_device"] = NetworkSettings.getHostname();
 }
 
 void MqttHandleHassClass::publish(const String& subtopic, const String& payload)

--- a/src/MqttHandleHass.cpp
+++ b/src/MqttHandleHass.cpp
@@ -113,6 +113,7 @@ void MqttHandleHassClass::publishDTUSensor(const char* name, const char* device_
         root["unit_of_meas"] = unit_of_measure;
     }
     root["stat_t"] = MqttSettings.getPrefix() + "dtu" + "/" + topic;
+    root["avty_t"] = MqttSettings.getPrefix() + "dtu" + "/" + "status";
 
     JsonObject deviceObj = root.createNestedObject("dev");
     createDTUDeviceInfo(deviceObj);


### PR DESCRIPTION
related to https://github.com/tbnobody/OpenDTU/issues/1359

This adds a dtu device with a WiFi Signal, IP, Status and Uptime sensor to Home Assistant. It also links the inverter to the dtu.

![Bildschirmfoto 2023-09-22 um 10 31 11](https://github.com/tbnobody/OpenDTU/assets/9592452/b2fb4c00-95d5-4071-9ad3-6030aec7f3b3)


DTU
<img width="570" alt="Bildschirmfoto 2023-09-21 um 08 53 14" src="https://github.com/tbnobody/OpenDTU/assets/9592452/e4e5b2ae-fb9f-4789-9471-56e2261ed029">

Inverter
<img width="285" alt="Bildschirmfoto 2023-09-21 um 00 14 26" src="https://github.com/tbnobody/OpenDTU/assets/9592452/a6bd0dc7-6e5f-4648-b5ba-605df3c5b804">


Open Topics:
- [x] Availability of IP, WiFi Signal and Uptime should be linked to Status topic to disable them once device goes offline.
- [ ] extend device classes
- [ ] add entity categories