### PR TITLE
Compute sun set only if necessary

### DIFF
--- a/include/InverterSettings.h
+++ b/include/InverterSettings.h
@@ -3,6 +3,8 @@
 
 #include <cstdint>
 
+#define INVERTER_UPDATE_SETTINGS_INTERVAL 60000l
+
 class InverterSettingsClass {
 public:
     void init();

--- a/include/SunPosition.h
+++ b/include/SunPosition.h
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 #pragma once
 
+#include <mutex>
 #include <sunset.h>
 
 #define SUNPOS_UPDATE_INTERVAL 60000l
@@ -15,9 +16,12 @@ public:
     bool isSunsetAvailable();
     bool sunsetTime(struct tm* info);
     bool sunriseTime(struct tm* info);
+    void setDoRecalc(bool doRecalc);
 
 private:
     void updateSunData();
+    bool checkRecalcDayChanged();
+    bool getDoRecalc();
 
     SunSet _sun;
     bool _isDayPeriod = true;
@@ -25,8 +29,10 @@ private:
     uint32_t _sunriseMinutes = 0;
     uint32_t _sunsetMinutes = 0;
 
-    uint32_t _lastUpdate = 0;
     bool _isValidInfo = false;
+    bool _doRecalc = true;
+    std::mutex _recalcLock;
+    uint32_t _lastSunPositionCalculatedYMD = 0;
 };
 
 extern SunPositionClass SunPosition;

--- a/include/SunPosition.h
+++ b/include/SunPosition.h
@@ -4,8 +4,6 @@
 #include <mutex>
 #include <sunset.h>
 
-#define SUNPOS_UPDATE_INTERVAL 60000l
-
 class SunPositionClass {
 public:
     SunPositionClass();

--- a/src/InverterSettings.cpp
+++ b/src/InverterSettings.cpp
@@ -90,7 +90,7 @@ void InverterSettingsClass::init()
 
 void InverterSettingsClass::loop()
 {
-    if (millis() - _lastUpdate > SUNPOS_UPDATE_INTERVAL) {
+    if (millis() - _lastUpdate > INVERTER_UPDATE_SETTINGS_INTERVAL) {
         const CONFIG_T& config = Configuration.get();
 
         for (uint8_t i = 0; i < INV_MAX_COUNT; i++) {

--- a/src/SunPosition.cpp
+++ b/src/SunPosition.cpp
@@ -19,9 +19,8 @@ void SunPositionClass::init()
 
 void SunPositionClass::loop()
 {
-    if (millis() - _lastUpdate > SUNPOS_UPDATE_INTERVAL) {
+    if (getDoRecalc() || checkRecalcDayChanged()) {
         updateSunData();
-        _lastUpdate = millis();
     }
 }
 
@@ -35,14 +34,50 @@ bool SunPositionClass::isSunsetAvailable()
     return _isSunsetAvailable;
 }
 
+void SunPositionClass::setDoRecalc(bool doRecalc)
+{
+    std::lock_guard<std::mutex> lock(_recalcLock);
+    _doRecalc = doRecalc;
+}
+
+bool SunPositionClass::getDoRecalc()
+{
+    std::lock_guard<std::mutex> lock(_recalcLock);
+    return _doRecalc;
+}
+
+bool SunPositionClass::checkRecalcDayChanged()
+{
+    time_t now;
+    struct tm timeinfo;
+
+    time(&now);
+    localtime_r(&now, &timeinfo); // don't use getLocalTime() as there could be a delay of 10ms
+
+    uint32_t ymd;
+    ymd = (timeinfo.tm_year << 9) |
+          (timeinfo.tm_mon  << 5) |
+          timeinfo.tm_mday;
+
+    if (_lastSunPositionCalculatedYMD != ymd) {
+        return true;
+    }
+    return false;
+}
+
+
 void SunPositionClass::updateSunData()
 {
-    CONFIG_T const& config = Configuration.get();
-    int offset = Utils::getTimezoneOffset() / 3600;
-    _sun.setPosition(config.Ntp_Latitude, config.Ntp_Longitude, offset);
-
     struct tm timeinfo;
-    if (!getLocalTime(&timeinfo, 5)) {
+    bool gotLocalTime;
+
+    gotLocalTime = getLocalTime(&timeinfo, 5);
+    _lastSunPositionCalculatedYMD = (timeinfo.tm_year << 9) |
+                                    (timeinfo.tm_mon << 5) |
+                                    timeinfo.tm_mday;
+    setDoRecalc(false);
+
+    if (!gotLocalTime) {
         _isDayPeriod = true;
         _sunriseMinutes = 0;
         _sunsetMinutes = 0;
@@ -50,6 +85,10 @@ void SunPositionClass::updateSunData()
         return;
     }
 
+    CONFIG_T const& config = Configuration.get();
+    int offset = Utils::getTimezoneOffset() / 3600;
+
+    _sun.setPosition(config.Ntp_Latitude, config.Ntp_Longitude, offset);
     _sun.setCurrentDate(1900 + timeinfo.tm_year, timeinfo.tm_mon + 1, timeinfo.tm_mday);
 
     double sunset_type;

--- a/src/WebApi_ntp.cpp
+++ b/src/WebApi_ntp.cpp
@@ -190,6 +190,8 @@ void WebApiNtpClass::onNtpAdminPost(AsyncWebServerRequest* request)
 
     NtpSettings.setServer();
     NtpSettings.setTimezone();
+
+    SunPosition.setDoRecalc(true);
 }
 
 void WebApiNtpClass::onNtpTimeGet(AsyncWebServerRequest* request)


### PR DESCRIPTION
Sunrise and -set must recomputed if one of the following conditions is met:
- The date changed (based on the selected timezone)
- Location (Lat/Lon) changed
- Sunset type changed

So instead of calculating that every minute just do it on update via web interface or date change.

If a new config is uploaded, the DTU gets restarted. There is no need to initiate a recalculation in this case.