### PR TITLE
Implemented mDNS

### DIFF
--- a/include/Configuration.h
+++ b/include/Configuration.h
@@ -66,6 +66,8 @@ struct CONFIG_T {
     char WiFi_Hostname[WIFI_MAX_HOSTNAME_STRLEN + 1];
     uint32_t WiFi_ApTimeout;
 
+    bool Mdns_Enabled;
+
     char Ntp_Server[NTP_MAX_SERVER_STRLEN + 1];
     char Ntp_Timezone[NTP_MAX_TIMEZONE_STRLEN + 1];
     char Ntp_TimezoneDescr[NTP_MAX_TIMEZONEDESCR_STRLEN + 1];

--- a/include/NetworkSettings.h
+++ b/include/NetworkSettings.h
@@ -59,6 +59,7 @@ public:
 private:
     void setHostname();
     void setStaticIp();
+    void handleMDNS();
     void setupMode();
     void NetworkEvent(WiFiEvent_t event);
     bool adminEnabled = true;
@@ -76,6 +77,7 @@ private:
     network_mode _networkMode = network_mode::Undefined;
     bool _ethConnected = false;
     std::vector<NetworkEventCbList_t> _cbEventList;
+    bool lastMdnsEnabled = false;
 };
 
 extern NetworkSettingsClass NetworkSettings;

--- a/include/defaults.h
+++ b/include/defaults.h
@@ -20,6 +20,8 @@
 #define WIFI_PASSWORD ""
 #define WIFI_DHCP true
 
+#define MDNS_ENABLED false
+
 #define NTP_SERVER "pool.ntp.org"
 #define NTP_TIMEZONE "CET-1CEST,M3.5.0,M10.5.0/3"
 #define NTP_TIMEZONEDESCR "Europe/Berlin"

--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -41,6 +41,9 @@ bool ConfigurationClass::write()
     wifi["hostname"] = config.WiFi_Hostname;
     wifi["aptimeout"] = config.WiFi_ApTimeout;
 
+    JsonObject mdns = doc.createNestedObject("mdns");
+    mdns["enabled"] = config.Mdns_Enabled;
+
     JsonObject ntp = doc.createNestedObject("ntp");
     ntp["server"] = config.Ntp_Server;
     ntp["timezone"] = config.Ntp_Timezone;
@@ -190,6 +193,9 @@ bool ConfigurationClass::read()
 
     config.WiFi_Dhcp = wifi["dhcp"] | WIFI_DHCP;
     config.WiFi_ApTimeout = wifi["aptimeout"] | ACCESS_POINT_TIMEOUT;
+
+    JsonObject mdns = doc["mdns"];
+    config.Mdns_Enabled = mdns["enabled"] | MDNS_ENABLED;
 
     JsonObject ntp = doc["ntp"];
     strlcpy(config.Ntp_Server, ntp["server"] | NTP_SERVER, sizeof(config.Ntp_Server));

--- a/src/NetworkSettings.cpp
+++ b/src/NetworkSettings.cpp
@@ -8,6 +8,7 @@
 #include "PinMapping.h"
 #include "Utils.h"
 #include "defaults.h"
+#include <ESPmDNS.h>
 #include <ETH.h>
 
 NetworkSettingsClass::NetworkSettingsClass()
@@ -107,6 +108,35 @@ void NetworkSettingsClass::raiseEvent(network_event event)
                 entry.cb(event);
             }
         }
+    }
+}
+
+void NetworkSettingsClass::handleMDNS()
+{
+    bool mdnsEnabled = Configuration.get().Mdns_Enabled;
+
+    if (lastMdnsEnabled == mdnsEnabled) {
+        return;
+    }
+
+    lastMdnsEnabled = mdnsEnabled;
+
+    MDNS.end();
+
+    if (!mdnsEnabled) {
+        return;
+    }
+
+    if (MDNS.begin(getHostname())) {
+        MessageOutput.print("MDNS responder starting...");
+
+        MDNS.addService("http", "tcp", 80);
+        MDNS.addService("opendtu", "tcp", 80);
+        MDNS.addServiceTxt("opendtu", "tcp", "git_hash", AUTO_GIT_HASH);
+
+        MessageOutput.println("done");
+    } else {
+        MessageOutput.println("Error setting up MDNS responder!");
     }
 }
 
@@ -218,6 +248,8 @@ void NetworkSettingsClass::loop()
     if (dnsServerStatus) {
         dnsServer->processNextRequest();
     }
+
+    handleMDNS();
 }
 
 void NetworkSettingsClass::applyConfig()

--- a/src/WebApi_network.cpp
+++ b/src/WebApi_network.cpp
@@ -76,6 +76,7 @@ void WebApiNetworkClass::onNetworkAdminGet(AsyncWebServerRequest* request)
     root["ssid"] = config.WiFi_Ssid;
     root["password"] = config.WiFi_Password;
     root["aptimeout"] = config.WiFi_ApTimeout;
+    root["mdnsenabled"] = config.Mdns_Enabled;
 
     response->setLength();
     request->send(response);
@@ -236,6 +237,7 @@ void WebApiNetworkClass::onNetworkAdminPost(AsyncWebServerRequest* request)
         config.WiFi_Dhcp = false;
     }
     config.WiFi_ApTimeout = root["aptimeout"].as<uint>();
+    config.Mdns_Enabled = root["mdnsenabled"].as<bool>();
     Configuration.write();
 
     retMsg["type"] = "success";

--- a/webapp/src/locales/de.json
+++ b/webapp/src/locales/de.json
@@ -402,7 +402,9 @@
         "ApTimeout": "AccessPoint Zeitlimit:",
         "ApTimeoutHint": "Zeit die der AccessPoint offen gehalten wird. Ein Wert von 0 bedeutet unendlich.",
         "Minutes": "Minuten",
-        "Save": "@:dtuadmin.Save"
+        "Save": "@:dtuadmin.Save",
+        "EnableMdns": "mDNS aktivieren",
+        "MdnsSettings": "mDNS-Einstellungen"
     },
     "mqttadmin": {
         "MqttSettings": "MQTT-Einstellungen",

--- a/webapp/src/locales/en.json
+++ b/webapp/src/locales/en.json
@@ -402,7 +402,9 @@
         "ApTimeout": "AccessPoint Timeout:",
         "ApTimeoutHint": "Time which the AccessPoint is kept open. A value of 0 means infinite.",
         "Minutes": "minutes",
-        "Save": "@:dtuadmin.Save"
+        "Save": "@:dtuadmin.Save",
+        "EnableMdns": "Enable mDNS",
+        "MdnsSettings": "mDNS Settings"
     },
     "mqttadmin": {
         "MqttSettings": "MQTT Settings",

--- a/webapp/src/locales/fr.json
+++ b/webapp/src/locales/fr.json
@@ -402,7 +402,9 @@
         "ApTimeout": "Délai d'attente du point d'accès",
         "ApTimeoutHint": "Durée pendant laquelle le point d'accès reste ouvert. Une valeur de 0 signifie infini.",
         "Minutes": "minutes",
-        "Save": "@:dtuadmin.Save"
+        "Save": "@:dtuadmin.Save",
+        "EnableMdns": "Activer mDNS",
+        "MdnsSettings": "mDNS Settings"
     },
     "mqttadmin": {
         "MqttSettings": "Paramètres MQTT",

--- a/webapp/src/types/NetworkConfig.ts
+++ b/webapp/src/types/NetworkConfig.ts
@@ -9,4 +9,5 @@ export interface NetworkConfig {
     dns1: string;
     dns2: string;
     aptimeout: number;
+    mdnsenabled: boolean;
 }

--- a/webapp/src/views/NetworkAdminView.vue
+++ b/webapp/src/views/NetworkAdminView.vue
@@ -50,6 +50,12 @@
                               type="text" maxlength="32"/>
             </CardElement>
 
+            <CardElement :text="$t('networkadmin.MdnsSettings')" textVariant="text-bg-primary" add-space>
+                <InputElement :label="$t('networkadmin.EnableMdns')"
+                              v-model="networkConfigList.mdnsenabled"
+                              type="checkbox"/>
+            </CardElement>
+
             <CardElement :text="$t('networkadmin.AdminAp')" textVariant="text-bg-primary" add-space>
                 <InputElement :label="$t('networkadmin.ApTimeout')"
                               v-model="networkConfigList.aptimeout"
@@ -67,7 +73,7 @@ import BasePage from '@/components/BasePage.vue';
 import BootstrapAlert from "@/components/BootstrapAlert.vue";
 import CardElement from '@/components/CardElement.vue';
 import InputElement from '@/components/InputElement.vue';
-import type { NetworkConfig } from "@/types/NetworkkConfig";
+import type { NetworkConfig } from "@/types/NetworkConfig";
 import { authHeader, handleResponse } from '@/utils/authentication';
 import { defineComponent } from 'vue';
 


### PR DESCRIPTION
This PR implements mDNS for OpenDTU. It adds two services, one for the commonly used _http._tcp service, and one custom one (_opendtu._tcp) for auto-discovery.

It also implements the needed changes for the Web-App.

Flash Statistics:

```sh
$ du .pio/build/generic_esp32/firmware.bin

# before: 1512
# after: 1540
```

This PR was inspired by https://github.com/tbnobody/OpenDTU/pull/695.