### PR TITLE
Define _TASK_THREAD_SAFE for TaskScheduler

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -24,6 +24,7 @@ platform = espressif32@6.5.0
 build_flags =
     -DPIOENV=\"$PIOENV\"
     -D_TASK_STD_FUNCTION=1
+    -D_TASK_THREAD_SAFE=1
     -Wall -Wextra -Wunused -Wmisleading-indentation -Wduplicated-cond -Wlogical-op -Wnull-dereference
 ;   Have to remove -Werror because of
 ;   https://github.com/espressif/arduino-esp32/issues/9044 and


### PR DESCRIPTION
I appreciate the use of TaskScheduler as an alternative to extending the `loop()` approach.

To make further use of TaskScheduler's features, it makes sense to me to change task scheduling intervals dynamically at runtime. Example: The MQTT loop is executed at a specific interval, the MQTT publish interval. Once the user changes this interval, the scheduling interval of the MQTT loop should be changed accordingly. The straight-forward approach is to call `setInterval()` in the respective web server handler. That will execute in the web server's context. Changing TaskScheduler task properties from another context is not inherently save.

In `platformio.ini`, the `build_flags` should use `-D_TASK_THREAD_SAFE` to enable the use of an internal mutex which prevents unexpected behavior once multiple threads (FreeRTOS tasks) start changing task or scheduler settings.

An excerpt from the [TaskScheduler docs](https://github.com/arkhipenko/TaskScheduler/wiki/Full-Document):
>> #define _TASK_THREAD_SAFE

> …will use an internal mutex to protect task scheduling methods from preemption and unexpected behavior. This is a recommended option for esp32 and/or other MCU's running TaskScheduler under preemptive scheduler like FreeRTOS.

The author suggests to define this flag when using TaskScheduler on ESP32.