### PR TITLE
Ux/UI improvements

### DIFF
--- a/webapp/src/App.vue
+++ b/webapp/src/App.vue
@@ -1,8 +1,6 @@
 <template>
     <NavBar />
-    <main class="container-fluid">
-        <router-view />
-    </main>
+    <router-view />
 </template>
 
 <script lang="ts">

--- a/webapp/src/components/InverterChannelInfo.vue
+++ b/webapp/src/components/InverterChannelInfo.vue
@@ -2,7 +2,7 @@
     <div class="card" :class="{
         'border-info': channelType == 'AC',
         'border-secondary': channelType == 'INV'
-    }">
+    }" style="overflow: hidden">
         <div v-if="channelType == 'INV'" class="card-header text-bg-secondary">
             {{ $t('inverterchannelinfo.General') }}
         </div>
@@ -16,32 +16,24 @@
             {{ $t('inverterchannelinfo.Phase', { num: channelNumber + 1 }) }}
         </div>
 
-        <div class="card-body">
-            <div class="table-responsive">
-                <table class="table table-striped table-hover">
-                    <thead>
-                        <tr>
-                            <th scope="col">{{ $t('inverterchannelinfo.Property') }}</th>
-                            <th style="text-align: right" scope="col">{{ $t('inverterchannelinfo.Value') }}</th>
-                            <th scope="col">{{ $t('inverterchannelinfo.Unit') }}</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <tr v-for="(property, key) in channelData" :key="`prop-${key}`">
-                            <template v-if="key != 'name' && property">
-                                <th scope="row">{{ $t('inverterchannelproperty.' + key) }}</th>
-                                <td style="text-align: right">
-                                    {{ $n(property.v, 'decimal', {
-                                        minimumFractionDigits: property.d,
-                                        maximumFractionDigits: property.d})
-                                    }}
-                                </td>
-                                <td>{{ property.u }}</td>
-                            </template>
-                        </tr>
-                    </tbody>
-                </table>
-            </div>
+        <div class="table-responsive">
+            <table class="table table-striped table-hover" style="margin: 0">
+                <tbody>
+                    <tr v-for="(property, key) in channelData" :key="`prop-${key}`">
+                        <template v-if="key != 'name' && property">
+                            <th scope="row">{{ $t('inverterchannelproperty.' + key) }}</th>
+                            <td style="text-align: right; padding-right: 0;">
+                                {{ $n(property.v, 'decimal', {
+                                    minimumFractionDigits: property.d,
+                                    maximumFractionDigits: property.d
+                                })
+                                }}
+                            </td>
+                            <td>{{ property.u }}</td>
+                        </template>
+                    </tr>
+                </tbody>
+            </table>
         </div>
     </div>
 </template>

--- a/webapp/src/components/NavBar.vue
+++ b/webapp/src/components/NavBar.vue
@@ -1,17 +1,14 @@
 <template>
     <nav class="navbar navbar-expand-md fixed-top bg-body-tertiary" data-bs-theme="dark">
         <div class="container-fluid">
-            <router-link @click="onClick" class="navbar-brand" to="/">
-                <span v-if="isXmas" class="text-success">
-                    <BIconTree width="30" height="30" class="d-inline-block align-text-top" />
-                </span>
-                <span v-else-if="isEaster" class="text-info">
-                    <BIconEgg width="30" height="30" class="d-inline-block align-text-top" />
-                </span>
-                <span v-else class="text-warning">
-                    <BIconSun width="30" height="30" class="d-inline-block align-text-top" />
-                </span>
-                <span style="vertical-align: middle;">
+            <router-link @click="onClick" class="navbar-brand" to="/" style="display: flex; height: 30px; padding: 0;">
+                <BIconTree v-if="isXmas" width="30" height="30" class="d-inline-block align-text-top text-success" />
+
+                <BIconEgg v-else-if="isEaster" width="30" height="30" class="d-inline-block align-text-top text-info" />
+
+                <BIconSun v-else width="30" height="30" class="d-inline-block align-text-top text-warning" />
+
+                <span style="margin-left: .5rem">
                     OpenDTU
                 </span>
             </router-link>
@@ -31,39 +28,49 @@
                         </a>
                         <ul class="dropdown-menu" aria-labelledby="navbarScrollingDropdown">
                             <li>
-                                <router-link @click="onClick" class="dropdown-item" to="/settings/network">{{ $t('menu.NetworkSettings') }}</router-link>
+                                <router-link @click="onClick" class="dropdown-item" to="/settings/network">{{
+                                    $t('menu.NetworkSettings') }}</router-link>
                             </li>
                             <li>
-                                <router-link @click="onClick" class="dropdown-item" to="/settings/ntp">{{ $t('menu.NTPSettings') }}</router-link>
+                                <router-link @click="onClick" class="dropdown-item" to="/settings/ntp">{{
+                                    $t('menu.NTPSettings') }}</router-link>
                             </li>
                             <li>
-                                <router-link @click="onClick" class="dropdown-item" to="/settings/mqtt">{{ $t('menu.MQTTSettings') }}</router-link>
+                                <router-link @click="onClick" class="dropdown-item" to="/settings/mqtt">{{
+                                    $t('menu.MQTTSettings') }}</router-link>
                             </li>
                             <li>
-                                <router-link @click="onClick" class="dropdown-item" to="/settings/inverter">{{ $t('menu.InverterSettings') }}
+                                <router-link @click="onClick" class="dropdown-item" to="/settings/inverter">{{
+                                    $t('menu.InverterSettings') }}
                                 </router-link>
                             </li>
                             <li>
-                                <router-link @click="onClick" class="dropdown-item" to="/settings/security">{{ $t('menu.SecuritySettings') }}
+                                <router-link @click="onClick" class="dropdown-item" to="/settings/security">{{
+                                    $t('menu.SecuritySettings') }}
                                 </router-link>
                             </li>
                             <li>
-                                <router-link @click="onClick" class="dropdown-item" to="/settings/dtu">{{ $t('menu.DTUSettings') }}</router-link>
+                                <router-link @click="onClick" class="dropdown-item" to="/settings/dtu">{{
+                                    $t('menu.DTUSettings') }}</router-link>
                             </li>
                             <li>
-                                <router-link @click="onClick" class="dropdown-item" to="/settings/device">{{ $t('menu.DeviceManager') }}</router-link>
+                                <router-link @click="onClick" class="dropdown-item" to="/settings/device">{{
+                                    $t('menu.DeviceManager') }}</router-link>
                             </li>
                             <li>
                                 <hr class="dropdown-divider" />
                             </li>
                             <li>
-                                <router-link @click="onClick" class="dropdown-item" to="/settings/config">{{ $t('menu.ConfigManagement') }}</router-link>
+                                <router-link @click="onClick" class="dropdown-item" to="/settings/config">{{
+                                    $t('menu.ConfigManagement') }}</router-link>
                             </li>
                             <li>
-                                <router-link @click="onClick" class="dropdown-item" to="/firmware/upgrade">{{ $t('menu.FirmwareUpgrade') }}</router-link>
+                                <router-link @click="onClick" class="dropdown-item" to="/firmware/upgrade">{{
+                                    $t('menu.FirmwareUpgrade') }}</router-link>
                             </li>
                             <li>
-                                <router-link @click="onClick" class="dropdown-item" to="/maintenance/reboot">{{ $t('menu.DeviceReboot') }}</router-link>
+                                <router-link @click="onClick" class="dropdown-item" to="/maintenance/reboot">{{
+                                    $t('menu.DeviceReboot') }}</router-link>
                             </li>
                         </ul>
                     </li>
@@ -74,22 +81,27 @@
                         </a>
                         <ul class="dropdown-menu" aria-labelledby="navbarScrollingDropdown">
                             <li>
-                                <router-link @click="onClick" class="dropdown-item" to="/info/system">{{ $t('menu.System') }}</router-link>
+                                <router-link @click="onClick" class="dropdown-item" to="/info/system">{{ $t('menu.System')
+                                }}</router-link>
                             </li>
                             <li>
-                                <router-link @click="onClick" class="dropdown-item" to="/info/network">{{ $t('menu.Network') }}</router-link>
+                                <router-link @click="onClick" class="dropdown-item" to="/info/network">{{ $t('menu.Network')
+                                }}</router-link>
                             </li>
                             <li>
-                                <router-link @click="onClick" class="dropdown-item" to="/info/ntp">{{ $t('menu.NTP') }}</router-link>
+                                <router-link @click="onClick" class="dropdown-item" to="/info/ntp">{{ $t('menu.NTP')
+                                }}</router-link>
                             </li>
                             <li>
-                                <router-link @click="onClick" class="dropdown-item" to="/info/mqtt">{{ $t('menu.MQTT') }}</router-link>
+                                <router-link @click="onClick" class="dropdown-item" to="/info/mqtt">{{ $t('menu.MQTT')
+                                }}</router-link>
                             </li>
                             <li>
                                 <hr class="dropdown-divider" />
                             </li>
                             <li>
-                                <router-link @click="onClick" class="dropdown-item" to="/info/console">{{ $t('menu.Console') }}</router-link>
+                                <router-link @click="onClick" class="dropdown-item" to="/info/console">{{ $t('menu.Console')
+                                }}</router-link>
                             </li>
                         </ul>
                     </li>
@@ -101,8 +113,10 @@
                     <ThemeSwitcher class="me-2" />
                     <form class="d-flex" role="search">
                         <LocaleSwitcher class="me-2" />
-                        <button v-if="isLogged" class="btn btn-outline-danger" @click="signout">{{ $t('menu.Logout') }}</button>
-                        <button v-if="!isLogged" class="btn btn-outline-success" @click="signin">{{ $t('menu.Login') }}</button>
+                        <button v-if="isLogged" class="btn btn-outline-danger" @click="signout">{{ $t('menu.Logout')
+                        }}</button>
+                        <button v-if="!isLogged" class="btn btn-outline-success" @click="signin">{{ $t('menu.Login')
+                        }}</button>
                     </form>
                 </ul>
             </div>

--- a/webapp/src/components/NavBar.vue
+++ b/webapp/src/components/NavBar.vue
@@ -11,7 +11,9 @@
                 <span v-else class="text-warning">
                     <BIconSun width="30" height="30" class="d-inline-block align-text-top" />
                 </span>
-                 OpenDTU
+                <span style="vertical-align: middle;">
+                    OpenDTU
+                </span>
             </router-link>
             <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNavAltMarkup"
                 aria-controls="navbarNavAltMarkup" aria-expanded="false" aria-label="Toggle navigation">


### PR DESCRIPTION
On my Samsung S22 Ultra which has one of the largest phone screens and with medium small text size, the home page has lots of redundant spacing, which leads to an unnecessary scrollbar in the inverter channel info tables.
Another reason for this is the table header, which - especially in German - makes the unit column much wider than necessary. As you can see the table is cut off having a scrollbar, even though the table content fits without a problem:

<img width="378" alt="grafik" src="https://github.com/tbnobody/OpenDTU/assets/9429273/f3f06913-5e97-42f7-868c-dc433802a69c">


<hr />


 #### This PR makes a few slight changes to use the space more wisely, along with a few other improvements:

Every View had a redundant main container with `class="container-fluid"`, causing unnecessary 1rem margin. This PR removes it:
<img width="460" alt="grafik" src="https://github.com/tbnobody/OpenDTU/assets/9429273/244d4df5-363f-4cb7-bfaa-773736f981e1">

<hr />

The Inverter Channel Info Table Header `Property | Value | Unit` caused layout shifting while (arguably) adding next to no value. This PR removes it, along with the table margin:

|Before|After|
|-|-|
| <img width="382" alt="grafik" src="https://github.com/tbnobody/OpenDTU/assets/9429273/ec0d13de-8889-44ea-be03-a3b4f6bdd87f"> | <img width="382" alt="grafik" src="https://github.com/tbnobody/OpenDTU/assets/9429273/2ce5e196-061a-4e5f-9565-91f9d9de86b9"> |

As you can see there's now a lot more available space in the table, meaning that scrollbar folding will only appear on very very small screens.

<hr />

Vertically Centering the OpenDTU Header Text and Icon

|Before|After|
|-|-|
| <img width="382" alt="grafik" src="https://github.com/tbnobody/OpenDTU/assets/9429273/dae7b749-84c4-45ba-b1db-bdeb1afea66b"> | <img width="382" alt="grafik" src="https://github.com/tbnobody/OpenDTU/assets/9429273/1ff63b22-b103-4609-bd21-a9448fff03b3"> |


