### PR TITLE
fix #1668

### DIFF
--- a/webapp/src/components/NavBar.vue
+++ b/webapp/src/components/NavBar.vue
@@ -17,7 +17,7 @@
                 <span class="navbar-toggler-icon"></span>
             </button>
             <div class="collapse navbar-collapse" ref="navbarCollapse" id="navbarNavAltMarkup">
-                <ul class="navbar-nav me-auto">
+                <ul class="navbar-nav navbar-nav-scroll d-flex me-auto flex-sm-fill">
                     <li class="nav-item">
                         <router-link @click="onClick" class="nav-link" to="/">{{ $t('menu.LiveView') }}</router-link>
                     </li>
@@ -93,8 +93,7 @@
                     <li class="nav-item">
                         <router-link @click="onClick" class="nav-link" to="/about">{{ $t('menu.About') }}</router-link>
                     </li>
-                </ul>
-                <ul class="navbar-nav flex-row flex-wrap ms-md-auto">
+                    <li class="flex-sm-fill"></li>
                     <ThemeSwitcher class="me-2" />
                     <form class="d-flex" role="search">
                         <LocaleSwitcher class="me-2" />


### PR DESCRIPTION
this PR enables scrolling for the menu popovers by restricting their height (or the entire menu height, respectively) to the viewport, both in expanded and collapsed (hamburger) state:
![grafik](https://github.com/tbnobody/OpenDTU/assets/9429273/6ee9a650-a2be-4eab-81c7-5431ba0438e5)
![grafik](https://github.com/tbnobody/OpenDTU/assets/9429273/5e593755-f44b-4732-b3bd-591244cc877e)


One question related to the contributing process:
What are the benefits of manually merging each PR?
It seems to me that it's just additional effort, plus keeping forks up to date cannot be done automatically by github, since you end up with duplicate commits.