### PR TITLE
MQTT LWT QoS support for TLS secured connections

### DIFF
--- a/src/MqttSettings.cpp
+++ b/src/MqttSettings.cpp
@@ -125,7 +125,7 @@ void MqttSettingsClass::performConnect()
             } else {
                 static_cast<espMqttClientSecure*>(_mqttClient)->setCredentials(config.Mqtt.Username, config.Mqtt.Password);
             }
-            static_cast<espMqttClientSecure*>(_mqttClient)->setWill(willTopic.c_str(), 2, config.Mqtt.Retain, config.Mqtt.Lwt.Value_Offline);
+            static_cast<espMqttClientSecure*>(_mqttClient)->setWill(willTopic.c_str(), config.Mqtt.Lwt.Qos, config.Mqtt.Retain, config.Mqtt.Lwt.Value_Offline);
             static_cast<espMqttClientSecure*>(_mqttClient)->setClientId(clientId.c_str());
             static_cast<espMqttClientSecure*>(_mqttClient)->setCleanSession(config.Mqtt.CleanSession);
             static_cast<espMqttClientSecure*>(_mqttClient)->onConnect(std::bind(&MqttSettingsClass::onMqttConnect, this, _1));

--- a/src/WebApi_mqtt.cpp
+++ b/src/WebApi_mqtt.cpp
@@ -79,7 +79,7 @@ void WebApiMqttClass::onMqttAdminGet(AsyncWebServerRequest* request)
     root["mqtt_client_cert"] = config.Mqtt.Tls.ClientCert;
     root["mqtt_client_key"] = config.Mqtt.Tls.ClientKey;
     root["mqtt_lwt_topic"] = config.Mqtt.Lwt.Topic;
-    root["mqtt_lwt_online"] = config.Mqtt.CleanSession;
+    root["mqtt_lwt_online"] = config.Mqtt.Lwt.Value_Online;;
     root["mqtt_lwt_offline"] = config.Mqtt.Lwt.Value_Offline;
     root["mqtt_lwt_qos"] = config.Mqtt.Lwt.Qos;
     root["mqtt_publish_interval"] = config.Mqtt.PublishInterval;


### PR DESCRIPTION
Resulting of the post-discussion from https://github.com/tbnobody/OpenDTU/issues/1514 I found that there was still a hardcoded QoS of "2" for TLS-configured connections in openDTU. This results in connection aborts on AWS IoT Core (as they don't support that feature for their MQTT 3.x implementation).

Side-Fix for the LWT Online Status message, which was always in "true" instead of defined text.

The PR fixes the issue. Build, Tested, Deployed, and already in use. 