### PR TITLE
Fix: make efficient use of available display area

### DIFF
--- a/src/Display_Graphic.cpp
+++ b/src/Display_Graphic.cpp
@@ -67,11 +67,19 @@ void DisplayGraphicClass::init(Scheduler& scheduler, const DisplayType_t type, c
 
 void DisplayGraphicClass::calcLineHeights()
 {
-    uint8_t yOff = 0;
+    bool diagram = (_isLarge && _diagram_mode == DiagramMode_t::Small);
+    // the diagram needs space. we need to keep
+    // away from the y-axis label in particular.
+    uint8_t yOff = (diagram?7:0);
     for (uint8_t i = 0; i < 4; i++) {
         setFont(i);
-        yOff += (_display->getMaxCharHeight());
+        yOff += _display->getAscent();
         _lineOffsets[i] = yOff;
+        yOff += ((!_isLarge || diagram)?2:3);
+        // the descent is a negative value and moves the *next* line's
+        // baseline. the first line never uses a letter with descent and
+        // we need that space when showing the small diagram.
+        yOff -= ((i == 0 && diagram)?0:_display->getDescent());
     }
 }
 

--- a/src/WebApi_device.cpp
+++ b/src/WebApi_device.cpp
@@ -166,12 +166,12 @@ void WebApiDeviceClass::onDeviceAdminPost(AsyncWebServerRequest* request)
         config.Led_Single[i].Brightness = min<uint8_t>(100, config.Led_Single[i].Brightness);
     }
 
+    Display.setDiagramMode(static_cast<DiagramMode_t>(config.Display.Diagram.Mode));
     Display.setOrientation(config.Display.Rotation);
     Display.enablePowerSafe = config.Display.PowerSafe;
     Display.enableScreensaver = config.Display.ScreenSaver;
     Display.setContrast(config.Display.Contrast);
     Display.setLanguage(config.Display.Language);
-    Display.setDiagramMode(static_cast<DiagramMode_t>(config.Display.Diagram.Mode));
     Display.Diagram().updatePeriod();
 
     WebApi.writeConfig(retMsg);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -120,12 +120,12 @@ void setup()
         pin.display_clk,
         pin.display_cs,
         pin.display_reset);
+    Display.setDiagramMode(static_cast<DiagramMode_t>(config.Display.Diagram.Mode));
     Display.setOrientation(config.Display.Rotation);
     Display.enablePowerSafe = config.Display.PowerSafe;
     Display.enableScreensaver = config.Display.ScreenSaver;
     Display.setContrast(config.Display.Contrast);
     Display.setLanguage(config.Display.Language);
-    Display.setDiagramMode(static_cast<DiagramMode_t>(config.Display.Diagram.Mode));
     Display.setStartupDisplay();
     MessageOutput.println("done");
 


### PR DESCRIPTION
Fixes calculation of the text baselines, using `getAscent()` in favor of `getMaxCharHeight()`, which includes ascent and descent. This moves the first text up and allows to insert margin between the lines until the display area is fully utilized.
    
On large displays, if the small diagram is selected, keep the first line rather low to avoid collision with the diagram y-axis label. in this mode, there is still more space between the text lines as before, allowing for improved readability.

I always thought that the display was quite crammed, especially the last line. While implementing https://github.com/helgeerbe/OpenDTU-OnBattery/pull/658 I noticed that something was off with the baselines and that we could do better without compromising, since the previous implementation wastes lines mainly on the bottom of the display, also on the top if no diagram is drawn. The y of today nearly touches the l of total.

![image](https://github.com/helgeerbe/OpenDTU-OnBattery/assets/3578416/1058ddb6-f8c9-4ccb-8dd2-e0e8d8e286d9)

I found that especially the baseline (`_lineOffsets`) for the first line was off. The reason is that `getMaxCharHeight()` returns a value greater than the font's ascent, i.e., it includes the font's descent. The value which should be used is `getAscent()`. The next line's baseline is then advanced by the previous line's descent, making sure that they will not collide.

![image](https://github.com/tbnobody/OpenDTU/assets/3578416/6d0ff07c-2c20-4ca9-b531-77928cabe01b)
![image](https://github.com/tbnobody/OpenDTU/assets/3578416/b4a9a7aa-05e0-4fcc-82de-a3def73d4e35)

The placement is such that even when using the screensaver with the small diagram, the solar power will not collide with the diagram y-axis label.

Using this code
```
    if (!_isLarge) {
        _display->drawBox(84, 0, 1, 49);
        _display->drawBox(0, 48, 84, 1);
    }
    _isLarge = (_mExtra % 40 < 20);
    calcLineHeights();
```
I made sure that the change works for small displays as well.

![image](https://github.com/tbnobody/OpenDTU/assets/3578416/8803720c-4b31-42db-8db7-1bf95ca1c50a)