### PR TITLE
implement oscillating screensaver

### DIFF
--- a/src/Display_Graphic.cpp
+++ b/src/Display_Graphic.cpp
@@ -103,27 +103,23 @@ void DisplayGraphicClass::printText(const char* text, const uint8_t line)
     if (!_isLarge) {
         dispX = (line == 0) ? 5 : 0;
     } else {
-        switch (line) {
-        case 0:
-            if (_diagram_mode == DiagramMode_t::Small) {
-                // Center between left border and diagram
-                dispX = (CHART_POSX - _display->getStrWidth(text)) / 2;
-            } else {
-                // Center on screen
-                dispX = (_display->getDisplayWidth() - _display->getStrWidth(text)) / 2;
-            }
-            break;
-        case 3:
+        if (line == 0 && _diagram_mode == DiagramMode_t::Small) {
+            // Center between left border and diagram
+            dispX = (CHART_POSX - _display->getStrWidth(text)) / 2;
+        } else {
             // Center on screen
             dispX = (_display->getDisplayWidth() - _display->getStrWidth(text)) / 2;
-            break;
-        default:
-            dispX = 5;
-            break;
         }
     }
 
-    dispX += enableScreensaver ? (_mExtra % 7) : 0;
+    if (enableScreensaver) {
+        unsigned maxOffset = (_isLarge?8:6);
+        unsigned period = 2 * maxOffset;
+        unsigned step = _mExtra % period;
+        int offset = (step <= maxOffset)?step:(period - step);
+        offset -= (_isLarge?5:0); // oscillate around center on large screens
+        dispX += offset;
+    }
     _display->drawStr(dispX, _lineOffsets[line], text);
 }
 


### PR DESCRIPTION
this implementation avoids the display content jumping the full screensaver offset from right to left when the modulo operator wraps. this change makes the display content walk from right to left as it did walk from left to right.

For large displays, this also centers the two middle text lines and makes the screensaver oscillate around the center.