### PR TITLE
WIP: implement and use Utils::checkJsonOverflow()

### DIFF
--- a/include/Utils.h
+++ b/include/Utils.h
@@ -11,5 +11,6 @@ public:
     static int getTimezoneOffset();
     static void restartDtu();
     static bool checkJsonAlloc(const DynamicJsonDocument& doc, const char* function, const uint16_t line);
+    static bool checkJsonOverflow(const DynamicJsonDocument& doc, const char* function, const uint16_t line);
     static void removeAllFiles();
 };

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -79,6 +79,16 @@ bool Utils::checkJsonAlloc(const DynamicJsonDocument& doc, const char* function,
     return true;
 }
 
+bool Utils::checkJsonOverflow(const DynamicJsonDocument& doc, const char* function, const uint16_t line)
+{
+    if (doc.overflowed()) {
+        MessageOutput.printf("DynamicJsonDocument overflowed: %s, %d\r\n", function, line);
+        return true;
+    }
+
+    return false;
+}
+
 /// @brief Remove all files but the PINMAPPING_FILENAME
 void Utils::removeAllFiles()
 {


### PR DESCRIPTION
this method calls the overflowed() method on the respective DynamicJsonDocument and prints a respective message if not all data could be added to the DynamicJsonDocument.

@tbnobody This is a proposal. I only used the new method in one spot. There are many more. Let me know what you think about this. I put this into OpenDTU-OnBattery (and used it on code specific to the downstream project) because I often find myself with problems in the web application that are caused by missing nodes in the respective JSON. I think is a valuable check to do right before serializing the JSON into a String buffer. Possibly, this new method can be changed to do the serialization and perform the check at the same time, so it becomes the standard to do both.