### PR TITLE
remove remaining usage of F() macro

### DIFF
--- a/lib/Hoymiles/src/inverters/HMT_4CH.cpp
+++ b/lib/Hoymiles/src/inverters/HMT_4CH.cpp
@@ -70,7 +70,7 @@ bool HMT_4CH::isValidSerial(const uint64_t serial)
 
 String HMT_4CH::typeName() const
 {
-    return F("HMT-1600/1800/2000-4T");
+    return "HMT-1600/1800/2000-4T";
 }
 
 const byteAssign_t* HMT_4CH::getByteAssignment() const

--- a/lib/Hoymiles/src/inverters/HMT_6CH.cpp
+++ b/lib/Hoymiles/src/inverters/HMT_6CH.cpp
@@ -84,7 +84,7 @@ bool HMT_6CH::isValidSerial(const uint64_t serial)
 
 String HMT_6CH::typeName() const
 {
-    return F("HMT-1800/2250-6T");
+    return "HMT-1800/2250-6T";
 }
 
 const byteAssign_t* HMT_6CH::getByteAssignment() const

--- a/src/InverterSettings.cpp
+++ b/src/InverterSettings.cpp
@@ -51,9 +51,9 @@ void InverterSettingsClass::init(Scheduler& scheduler)
 
         if (PinMapping.isValidCmt2300Config()) {
             Hoymiles.initCMT(pin.cmt_sdio, pin.cmt_clk, pin.cmt_cs, pin.cmt_fcs, pin.cmt_gpio2, pin.cmt_gpio3);
-            MessageOutput.println(F("  Setting country mode... "));
+            MessageOutput.println("  Setting country mode... ");
             Hoymiles.getRadioCmt()->setCountryMode(static_cast<CountryModeId_t>(config.Dtu.Cmt.CountryMode));
-            MessageOutput.println(F("  Setting CMT target frequency... "));
+            MessageOutput.println("  Setting CMT target frequency... ");
             Hoymiles.getRadioCmt()->setInverterTargetFrequency(config.Dtu.Cmt.Frequency);
         }
 


### PR DESCRIPTION
Given you removed most uses of said macro in d6028cbd, I guess these remaining four occurrences slipped through.