### PR TITLE
Feature: show ESP32 flash memory size in system info

### DIFF
--- a/src/WebApi_sysstatus.cpp
+++ b/src/WebApi_sysstatus.cpp
@@ -48,6 +48,7 @@ void WebApiSysstatusClass::onSystemStatus(AsyncWebServerRequest* request)
     root["chiprevision"] = ESP.getChipRevision();
     root["chipmodel"] = ESP.getChipModel();
     root["chipcores"] = ESP.getChipCores();
+    root["flashsize"] = ESP.getFlashChipSize();
 
     String reason;
     reason = ResetReason::get_reset_reason_verbose(0);

--- a/webapp/src/components/HardwareInfo.vue
+++ b/webapp/src/components/HardwareInfo.vue
@@ -19,6 +19,13 @@
                         <th>{{ $t('hardwareinfo.CpuFrequency') }}</th>
                         <td>{{ systemStatus.cpufreq }} {{ $t('hardwareinfo.Mhz') }}</td>
                     </tr>
+                    <tr>
+                        <th>{{ $t('hardwareinfo.FlashSize') }}</th>
+                        <td>
+                            {{ systemStatus.flashsize }} {{ $t('hardwareinfo.Bytes') }}
+                            ({{ systemStatus.flashsize / 1024 / 1024 }} {{ $t('hardwareinfo.MegaBytes') }})
+                        </td>
+                    </tr>
                 </tbody>
             </table>
         </div>

--- a/webapp/src/locales/de.json
+++ b/webapp/src/locales/de.json
@@ -202,7 +202,10 @@
         "ChipRevision": "Chip-Revision",
         "ChipCores": "Chip-Kerne",
         "CpuFrequency": "CPU-Frequenz",
-        "Mhz": "MHz"
+        "Mhz": "MHz",
+        "FlashSize": "Flash-Speichergröße",
+        "Bytes": "Bytes",
+        "MegaBytes": "MB"
     },
     "memoryinfo": {
         "MemoryInformation": "Speicherinformationen",

--- a/webapp/src/locales/en.json
+++ b/webapp/src/locales/en.json
@@ -202,7 +202,10 @@
         "ChipRevision": "Chip Revision",
         "ChipCores": "Chip Cores",
         "CpuFrequency": "CPU Frequency",
-        "Mhz": "MHz"
+        "Mhz": "MHz",
+        "FlashSize": "Flash Memory Size",
+        "Bytes": "Bytes",
+        "MegaBytes": "MB"
     },
     "memoryinfo": {
         "MemoryInformation": "Memory Information",

--- a/webapp/src/locales/fr.json
+++ b/webapp/src/locales/fr.json
@@ -202,7 +202,10 @@
         "ChipRevision": "Révision de la puce",
         "ChipCores": "Nombre de cœurs",
         "CpuFrequency": "Fréquence du CPU",
-        "Mhz": "MHz"
+        "Mhz": "MHz",
+        "FlashSize": "Taille de la mémoire flash",
+        "Bytes": "octets",
+        "MegaBytes": "Mo"
     },
     "memoryinfo": {
         "MemoryInformation": "Informations sur la mémoire",

--- a/webapp/src/types/SystemStatus.ts
+++ b/webapp/src/types/SystemStatus.ts
@@ -4,6 +4,7 @@ export interface SystemStatus {
     chiprevision: number;
     chipcores: number;
     cpufreq: number;
+    flashsize: number;
     // FirmwareInfo
     hostname: string;
     sdkversion: string;


### PR DESCRIPTION
This change adds a line to the system information of the web UI that lists the available amount of flash memory.

This info is vital for users of OpenDTU-OnBattery, as we have to insist on the availability of 8 MB of flash memory in the near future. This new line helps determine how much flash is actually available on a user's board.

![Screenshot from 2024-05-27 21-55-42](https://github.com/tbnobody/OpenDTU/assets/3578416/f79b8e94-ae77-4016-89d2-429874e22862)

Maybe this is interesting here as well?

