### PR TITLE
Add Support for W5500 SPI Ethernet Controller (without multiple devices using the same SPI bus)

### DIFF
--- a/.github/workflows/cpplint.yml
+++ b/.github/workflows/cpplint.yml
@@ -18,4 +18,4 @@ jobs:
           pip install cpplint
       - name: Linting
         run: |
-          cpplint --repository=. --recursive --filter=-build/c++11,-runtime/references,-readability/braces,-whitespace,-legal,-build/include ./src ./include ./lib/Hoymiles ./lib/MqttSubscribeParser ./lib/TimeoutHelper ./lib/ResetReason
+          cpplint --repository=. --recursive --filter=-build/c++11,-runtime/references,-readability/braces,-whitespace,-legal,-build/include ./src ./include ./lib/Hoymiles ./lib/MqttSubscribeParser ./lib/TimeoutHelper ./lib/ResetReason ./lib/ETHSPI

--- a/include/NetworkSettings.h
+++ b/include/NetworkSettings.h
@@ -83,6 +83,7 @@ private:
     bool _ethConnected = false;
     std::vector<NetworkEventCbList_t> _cbEventList;
     bool _lastMdnsEnabled = false;
+    bool _spiEth = false;
 };
 
 extern NetworkSettingsClass NetworkSettings;

--- a/include/PinMapping.h
+++ b/include/PinMapping.h
@@ -26,6 +26,13 @@ struct PinMapping_t {
     int8_t cmt_gpio3;
     int8_t cmt_sdio;
 
+    int8_t w5500_sclk;
+    int8_t w5500_mosi;
+    int8_t w5500_miso;
+    int8_t w5500_cs;
+    int8_t w5500_int;
+    int8_t w5500_rst;
+
     int8_t eth_phy_addr;
     bool eth_enabled;
     int eth_power;
@@ -49,6 +56,7 @@ public:
 
     bool isValidNrf24Config() const;
     bool isValidCmt2300Config() const;
+    bool isValidW5500Config() const;
     bool isValidEthConfig() const;
 
 private:

--- a/lib/ETHSPI/src/ETHSPI.cpp
+++ b/lib/ETHSPI/src/ETHSPI.cpp
@@ -1,0 +1,121 @@
+#include "ETHSPI.h"
+
+#include <driver/spi_master.h>
+
+// Functions from WiFiGeneric
+void tcpipInit();
+void add_esp_interface_netif(esp_interface_t interface, esp_netif_t* esp_netif);
+
+ETHSPIClass::ETHSPIClass() :
+    eth_handle(nullptr),
+    eth_netif(nullptr)
+{
+
+}
+
+void ETHSPIClass::begin(int8_t pin_sclk, int8_t pin_mosi, int8_t pin_miso, int8_t pin_cs, int8_t pin_int, int8_t pin_rst, spi_host_device_t host_id)
+{
+    gpio_reset_pin(static_cast<gpio_num_t>(pin_rst));
+    gpio_set_direction(static_cast<gpio_num_t>(pin_rst), GPIO_MODE_OUTPUT);
+    gpio_set_level(static_cast<gpio_num_t>(pin_rst), 0);
+
+    gpio_reset_pin(static_cast<gpio_num_t>(pin_sclk));
+    gpio_reset_pin(static_cast<gpio_num_t>(pin_mosi));
+    gpio_reset_pin(static_cast<gpio_num_t>(pin_miso));
+    gpio_reset_pin(static_cast<gpio_num_t>(pin_cs));
+    gpio_set_pull_mode(static_cast<gpio_num_t>(pin_miso), GPIO_PULLUP_ONLY);
+
+    // Workaround, because calling gpio_install_isr_service directly causes issues with attachInterrupt later
+    attachInterrupt(digitalPinToInterrupt(pin_int), nullptr, CHANGE);
+    detachInterrupt(digitalPinToInterrupt(pin_int));
+    gpio_reset_pin(static_cast<gpio_num_t>(pin_int));
+    gpio_set_pull_mode(static_cast<gpio_num_t>(pin_int), GPIO_PULLUP_ONLY);
+
+    spi_bus_config_t buscfg = {
+        .mosi_io_num = pin_mosi,
+        .miso_io_num = pin_miso,
+        .sclk_io_num = pin_sclk,
+        .quadwp_io_num = -1,
+        .quadhd_io_num = -1,
+        .data4_io_num = -1,
+        .data5_io_num = -1,
+        .data6_io_num = -1,
+        .data7_io_num = -1,
+        .max_transfer_sz = 0, // uses default value internally
+        .flags = 0,
+        .intr_flags = 0
+    };
+
+    ESP_ERROR_CHECK(spi_bus_initialize(host_id, &buscfg, SPI_DMA_CH_AUTO));
+
+    spi_device_interface_config_t devcfg = {
+        .command_bits = 16, // actually address phase
+        .address_bits = 8, // actually command phase
+        .dummy_bits = 0,
+        .mode = 0,
+        .duty_cycle_pos = 0,
+        .cs_ena_pretrans = 0, // only 0 supported
+        .cs_ena_posttrans = 0, // only 0 supported
+        .clock_speed_hz = 20000000, // stable with on OpenDTU Fusion Shield
+        .input_delay_ns = 0,
+        .spics_io_num = pin_cs,
+        .flags = 0,
+        .queue_size = 20,
+        .pre_cb = nullptr,
+        .post_cb = nullptr
+    };
+
+    spi_device_handle_t spi;
+    ESP_ERROR_CHECK(spi_bus_add_device(host_id, &devcfg, &spi));
+
+    // Reset sequence
+    delayMicroseconds(500);
+    gpio_set_level(static_cast<gpio_num_t>(pin_rst), 1);
+    delayMicroseconds(1000);
+
+    // Arduino function to start networking stack if not already started
+    tcpipInit();
+
+    ESP_ERROR_CHECK(tcpip_adapter_set_default_eth_handlers()); // ?
+
+    eth_w5500_config_t w5500_config = ETH_W5500_DEFAULT_CONFIG(spi);
+    w5500_config.int_gpio_num = pin_int;
+
+    eth_mac_config_t mac_config = ETH_MAC_DEFAULT_CONFIG();
+    mac_config.rx_task_stack_size = 4096;
+    esp_eth_mac_t *mac = esp_eth_mac_new_w5500(&w5500_config, &mac_config);
+
+    eth_phy_config_t phy_config = ETH_PHY_DEFAULT_CONFIG();
+    phy_config.reset_gpio_num = -1;
+    esp_eth_phy_t *phy = esp_eth_phy_new_w5500(&phy_config);
+
+    esp_eth_config_t eth_config = ETH_DEFAULT_CONFIG(mac, phy);
+    ESP_ERROR_CHECK(esp_eth_driver_install(&eth_config, &eth_handle));
+
+    // Configure MAC address
+    uint8_t mac_addr[6];
+    ESP_ERROR_CHECK(esp_efuse_mac_get_default(mac_addr));
+    mac_addr[5] |= 0x03; // derive ethernet MAC address from base MAC address
+    ESP_ERROR_CHECK(esp_eth_ioctl(eth_handle, ETH_CMD_S_MAC_ADDR, mac_addr));
+
+    esp_netif_config_t netif_config = ESP_NETIF_DEFAULT_ETH();
+    eth_netif = esp_netif_new(&netif_config);
+
+    ESP_ERROR_CHECK(esp_netif_attach(eth_netif, esp_eth_new_netif_glue(eth_handle)));
+
+    // Add to Arduino
+    add_esp_interface_netif(ESP_IF_ETH, eth_netif);
+
+    ESP_ERROR_CHECK(esp_eth_start(eth_handle));
+}
+
+String ETHSPIClass::macAddress()
+{
+    uint8_t mac_addr[6] = {0, 0, 0, 0, 0, 0};
+    esp_eth_ioctl(eth_handle, ETH_CMD_G_MAC_ADDR, mac_addr);
+    char mac_addr_str[24];
+    snprintf(mac_addr_str, sizeof(mac_addr_str), "%02X:%02X:%02X:%02X:%02X:%02X", mac_addr[0], mac_addr[1], mac_addr[2], mac_addr[3], mac_addr[4], mac_addr[5]);
+    return String(mac_addr_str);
+}
+
+ETHSPIClass ETHSPI;

--- a/lib/ETHSPI/src/ETHSPI.h
+++ b/lib/ETHSPI/src/ETHSPI.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <Arduino.h>
+#include <esp_netif.h>
+#include <driver/spi_master.h>
+
+class ETHSPIClass
+{
+private:
+    esp_eth_handle_t eth_handle;
+    esp_netif_t *eth_netif;
+
+public:
+    ETHSPIClass();
+
+    void begin(int8_t pin_sclk, int8_t pin_mosi, int8_t pin_miso, int8_t pin_cs, int8_t pin_int, int8_t pin_rst, spi_host_device_t host_id);
+    String macAddress();
+};
+
+extern ETHSPIClass ETHSPI;

--- a/src/PinMapping.cpp
+++ b/src/PinMapping.cpp
@@ -84,6 +84,30 @@
 #define CMT_SDIO -1
 #endif
 
+#ifndef W5500_SCLK
+#define W5500_SCLK -1
+#endif
+
+#ifndef W5500_MOSI
+#define W5500_MOSI -1
+#endif
+
+#ifndef W5500_MISO
+#define W5500_MISO -1
+#endif
+
+#ifndef W5500_CS
+#define W5500_CS -1
+#endif
+
+#ifndef W5500_INT
+#define W5500_INT -1
+#endif
+
+#ifndef W5500_RST
+#define W5500_RST -1
+#endif
+
 PinMappingClass PinMapping;
 
 PinMappingClass::PinMappingClass()
@@ -102,6 +126,13 @@ PinMappingClass::PinMappingClass()
     _pinMapping.cmt_gpio2 = CMT_GPIO2;
     _pinMapping.cmt_gpio3 = CMT_GPIO3;
     _pinMapping.cmt_sdio = CMT_SDIO;
+
+    _pinMapping.w5500_sclk = W5500_SCLK;
+    _pinMapping.w5500_mosi = W5500_MOSI;
+    _pinMapping.w5500_miso = W5500_MISO;
+    _pinMapping.w5500_cs = W5500_CS;
+    _pinMapping.w5500_int = W5500_INT;
+    _pinMapping.w5500_rst = W5500_RST;
 
 #ifdef OPENDTU_ETHERNET
     _pinMapping.eth_enabled = true;
@@ -164,6 +195,13 @@ bool PinMappingClass::init(const String& deviceMapping)
             _pinMapping.cmt_gpio3 = doc[i]["cmt"]["gpio3"] | CMT_GPIO3;
             _pinMapping.cmt_sdio = doc[i]["cmt"]["sdio"] | CMT_SDIO;
 
+            _pinMapping.w5500_sclk = doc[i]["w5500"]["sclk"] | W5500_SCLK;
+            _pinMapping.w5500_mosi = doc[i]["w5500"]["mosi"] | W5500_MOSI;
+            _pinMapping.w5500_miso = doc[i]["w5500"]["miso"] | W5500_MISO;
+            _pinMapping.w5500_cs = doc[i]["w5500"]["cs"] | W5500_CS;
+            _pinMapping.w5500_int = doc[i]["w5500"]["int"] | W5500_INT;
+            _pinMapping.w5500_rst = doc[i]["w5500"]["rst"] | W5500_RST;
+
 #ifdef OPENDTU_ETHERNET
             _pinMapping.eth_enabled = doc[i]["eth"]["enabled"] | true;
 #else
@@ -209,6 +247,16 @@ bool PinMappingClass::isValidCmt2300Config() const
         && _pinMapping.cmt_cs >= 0
         && _pinMapping.cmt_fcs >= 0
         && _pinMapping.cmt_sdio >= 0;
+}
+
+bool PinMappingClass::isValidW5500Config() const
+{
+    return _pinMapping.w5500_sclk >= 0
+        && _pinMapping.w5500_mosi >= 0
+        && _pinMapping.w5500_miso >= 0
+        && _pinMapping.w5500_cs >= 0
+        && _pinMapping.w5500_int >= 0
+        && _pinMapping.w5500_rst >= 0;
 }
 
 bool PinMappingClass::isValidEthConfig() const

--- a/src/WebApi_device.cpp
+++ b/src/WebApi_device.cpp
@@ -50,6 +50,14 @@ void WebApiDeviceClass::onDeviceAdminGet(AsyncWebServerRequest* request)
     cmtPinObj["gpio2"] = pin.cmt_gpio2;
     cmtPinObj["gpio3"] = pin.cmt_gpio3;
 
+    auto w5500PinObj = curPin["w5500"].to<JsonObject>();
+    w5500PinObj["sclk"] = pin.w5500_sclk;
+    w5500PinObj["mosi"] = pin.w5500_mosi;
+    w5500PinObj["miso"] = pin.w5500_miso;
+    w5500PinObj["cs"] = pin.w5500_cs;
+    w5500PinObj["int"] = pin.w5500_int;
+    w5500PinObj["rst"] = pin.w5500_rst;
+
     auto ethPinObj = curPin["eth"].to<JsonObject>();
     ethPinObj["enabled"] = pin.eth_enabled;
     ethPinObj["phy_addr"] = pin.eth_phy_addr;


### PR DESCRIPTION
With the upcoming end of support of devices with 4 MB flash on OpenDTU-OnBattery [(#1025)](https://github.com/helgeerbe/OpenDTU-OnBattery/issues/1025) there is an upcoming problem with the ethernet support. Currently there is no S3-Version of the WT32-ETH01 and also the S3 doesn't include an Ethernet MAC anymore.

So I started to research alternatives and found the W5500. Based on #1200 I've updated to master and simplified the implementation by e.g. removing the SpiPatcher logic. This way the libraries (NRF + CMT) don't need to be modified.

As a trade-off with this branch it is only possible to connect the W5500 with NRF or W5500 with CMT or NRF and CMT without ethernet. Furthermore because SPI3_HOST is not available on e.g. C3 the W5500 will not work and a warning will be outputted.

Multiple devices using the same SPI bus (implemented in #1200) would be best option for the future, but for now I think this is the fastest way to implement the W5500 without doing changes to other libraries.

I hope we can merge this PR into the master, so that there is an option for S3 + Ethernet in the future.