### PR TITLE
Use long int format specifiers

### DIFF
--- a/include/defaults.h
+++ b/include/defaults.h
@@ -3,7 +3,7 @@
 
 #define SERIAL_BAUDRATE 115200
 
-#define APP_HOSTNAME "OpenDTU-%06X"
+#define APP_HOSTNAME "OpenDTU-%06lX"
 
 #define HTTP_PORT 80
 

--- a/src/NetworkSettings.cpp
+++ b/src/NetworkSettings.cpp
@@ -207,7 +207,7 @@ void NetworkSettingsClass::loop()
         if (_adminEnabled && _adminTimeoutCounterMax > 0) {
             _adminTimeoutCounter++;
             if (_adminTimeoutCounter % 10 == 0) {
-                MessageOutput.printf("Admin AP remaining seconds: %d / %d\r\n", _adminTimeoutCounter, _adminTimeoutCounterMax);
+                MessageOutput.printf("Admin AP remaining seconds: %ld / %ld\r\n", _adminTimeoutCounter, _adminTimeoutCounterMax);
             }
         }
         _connectTimeoutTimer++;

--- a/src/WebApi_dtu.cpp
+++ b/src/WebApi_dtu.cpp
@@ -49,7 +49,7 @@ void WebApiDtuClass::onDtuAdminGet(AsyncWebServerRequest* request)
 
     // DTU Serial is read as HEX
     char buffer[sizeof(uint64_t) * 8 + 1];
-    snprintf(buffer, sizeof(buffer), "%0x%08x",
+    snprintf(buffer, sizeof(buffer), "%0lx%08x",
         ((uint32_t)((config.Dtu.Serial >> 32) & 0xFFFFFFFF)),
         ((uint32_t)(config.Dtu.Serial & 0xFFFFFFFF)));
     root["serial"] = buffer;

--- a/src/WebApi_inverter.cpp
+++ b/src/WebApi_inverter.cpp
@@ -44,7 +44,7 @@ void WebApiInverterClass::onInverterList(AsyncWebServerRequest* request)
 
             // Inverter Serial is read as HEX
             char buffer[sizeof(uint64_t) * 8 + 1];
-            snprintf(buffer, sizeof(buffer), "%0x%08x",
+            snprintf(buffer, sizeof(buffer), "%0lx%08lx",
                 ((uint32_t)((config.Inverter[i].Serial >> 32) & 0xFFFFFFFF)),
                 ((uint32_t)(config.Inverter[i].Serial & 0xFFFFFFFF)));
             obj["serial"] = buffer;

--- a/src/WebApi_ws_live.cpp
+++ b/src/WebApi_ws_live.cpp
@@ -208,9 +208,9 @@ void WebApiWsLiveClass::addTotalField(JsonObject& root, const String& name, cons
 void WebApiWsLiveClass::onWebsocketEvent(AsyncWebSocket* server, AsyncWebSocketClient* client, AwsEventType type, void* arg, uint8_t* data, size_t len)
 {
     if (type == WS_EVT_CONNECT) {
-        MessageOutput.printf("Websocket: [%s][%u] connect\r\n", server->url(), client->id());
+        MessageOutput.printf("Websocket: [%s][%lu] connect\r\n", server->url(), client->id());
     } else if (type == WS_EVT_DISCONNECT) {
-        MessageOutput.printf("Websocket: [%s][%u] disconnect\r\n", server->url(), client->id());
+        MessageOutput.printf("Websocket: [%s][%lu] disconnect\r\n", server->url(), client->id());
     }
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -143,9 +143,9 @@ void setup()
     if (config.Dtu.Serial == DTU_SERIAL) {
         MessageOutput.print("generate serial based on ESP chip id: ");
         const uint64_t dtuId = Utils::generateDtuSerial();
-        MessageOutput.printf("%0x%08x... ",
-            ((uint32_t)((dtuId >> 32) & 0xFFFFFFFF)),
-            ((uint32_t)(dtuId & 0xFFFFFFFF)));
+        MessageOutput.printf("%0llux%08llux... ",
+            (dtuId >> 32) & 0xFFFFFFFF,
+            dtuId & 0xFFFFFFFF);
         config.Dtu.Serial = dtuId;
         Configuration.write();
     }


### PR DESCRIPTION
Long integers should be prefixed with l in format strings.

My compiler won't let me compile without fixing this.