### PR TITLE
Support MQTT CA certificate validation for Azure Event Grid

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -27,6 +27,7 @@ build_flags =
     -D_TASK_THREAD_SAFE=1
     -DCONFIG_ASYNC_TCP_EVENT_QUEUE_SIZE=128
     -DCONFIG_ASYNC_TCP_QUEUE_SIZE=128
+    -DEMC_TASK_STACK_SIZE=6400
     -Wall -Wextra -Wunused -Wmisleading-indentation -Wduplicated-cond -Wlogical-op -Wnull-dereference
 ;   Have to remove -Werror because of
 ;   https://github.com/espressif/arduino-esp32/issues/9044 and


### PR DESCRIPTION
The use case is to publish MQTT events to the [Azure Event Grid broker](https://learn.microsoft.com/en-us/azure/event-grid/mqtt-overview). You will get a MQTT server url in the form of `*.germanywestcentral-1.ts.eventgrid.azure.net:8883`. Only secure TLS connections [are supported](https://learn.microsoft.com/en-us/azure/event-grid/mqtt-transport-layer-security-flow).

During the handshake the ESP produces are core dump and enters a reboot loop since the stack limit is reached for the MQTT task that is used for communicating to the broker. The last visible debug message on serial is
```
[  6550][V][ssl_client.cpp:269] start_ssl_client(): Performing the SSL/TLS handshake...
```

The default stack size is defined in the [espMqttClient](https://github.com/bertmelis/espMqttClient/blob/v1.7.0/src/Config.h#L53) to
```
#define EMC_TASK_STACK_SIZE 5120
```
From debugging the required stack size seems to be 5268 bytes though. Therefore suggesting to increase the stack for the task to 6400 bytes which seems to be working fine with this broker (tested 24 hours).

This resolves #2110