### PR TITLE
#618 fix: explicitly disconnect prior connecting to wifi

### DIFF
--- a/src/NetworkSettings.cpp
+++ b/src/NetworkSettings.cpp
@@ -27,6 +27,8 @@ void NetworkSettingsClass::init(Scheduler& scheduler)
     WiFi.setScanMethod(WIFI_ALL_CHANNEL_SCAN);
     WiFi.setSortMethod(WIFI_CONNECT_AP_BY_SIGNAL);
 
+    WiFi.disconnect(true, true);
+
     WiFi.onEvent(std::bind(&NetworkSettingsClass::NetworkEvent, this, _1));
     setupMode();
 
@@ -77,6 +79,7 @@ void NetworkSettingsClass::NetworkEvent(const WiFiEvent_t event)
         MessageOutput.println("WiFi disconnected");
         if (_networkMode == network_mode::WiFi) {
             MessageOutput.println("Try reconnecting");
+            WiFi.disconnect(true, true);
             WiFi.reconnect();
             raiseEvent(network_event::NETWORK_DISCONNECTED);
         }


### PR DESCRIPTION
See https://github.com/tbnobody/OpenDTU/issues/618#issuecomment-1661855347

It is a very old change in my installation, that I just noticed to have missed to open a pr for. Hopefully I remember the facts correctly.

The problem arises with the ap, being connected to, (temporarily) disappearing *) and requiring usage of a new "association packet" content (here: due to ap having changed the frequency).
The client wifi keeps the old one used initially (even across a soft-reset) and fails to connect to that ap then - endlessly.
To get it connected again actually power needs to be switched off. Or making the client "forgetting" this spcial packet prior trying to (re-)connect.


*) here, may be of interest, too, as I guess widely unknown: https://avm.de/service/wissensdatenbank/dok/FRITZ-Box-7490/1349_5-GHz-Funknetz-gelegentlich-deaktiviert-Radar-Signal/
Can be seen in the fritzbox events. To get around this, do not use automated frequency setting but fixed one outside radar ones.