### PR TITLE
fix: set sunset availability to false when its not available

### DIFF
--- a/src/SunPosition.cpp
+++ b/src/SunPosition.cpp
@@ -73,7 +73,7 @@ void SunPositionClass::updateSunData()
     if (!gotLocalTime) {
         _sunriseMinutes = 0;
         _sunsetMinutes = 0;
-        _isSunsetAvailable = true;
+        _isSunsetAvailable = false;
         _isValidInfo = false;
         return;
     }


### PR DESCRIPTION
While reading through the class to understand how we can use it to detect day and night in other parts of the project i stumbled across this line that is setting `_isSunsetAvailable` to `true` when we could not get the local time.

I assumed that this is a typo because I understood it that way that we can use `isSunsetAvailable()` to get if we can rely on `isDayPeriod()` or not.

Please let me know if my assumption is correct or if i misunderstood how this class works.