### PR TITLE
Publish ESP heap and temperature details on MQTT

### DIFF
--- a/src/MqttHandleDtu.cpp
+++ b/src/MqttHandleDtu.cpp
@@ -7,6 +7,7 @@
 #include "MqttSettings.h"
 #include "NetworkSettings.h"
 #include <Hoymiles.h>
+#include <CpuTemperature.h>
 
 MqttHandleDtuClass MqttHandleDtu;
 
@@ -34,6 +35,11 @@ void MqttHandleDtuClass::loop()
     MqttSettings.publish("dtu/uptime", String(millis() / 1000));
     MqttSettings.publish("dtu/ip", NetworkSettings.localIP().toString());
     MqttSettings.publish("dtu/hostname", NetworkSettings.getHostname());
+    MqttSettings.publish("dtu/temperature", String(CpuTemperature.read()));
+    MqttSettings.publish("dtu/heap/size", String(ESP.getHeapSize()));
+    MqttSettings.publish("dtu/heap/free", String(ESP.getFreeHeap()));
+    MqttSettings.publish("dtu/heap/minfree", String(ESP.getMinFreeHeap()));
+    MqttSettings.publish("dtu/heap/maxalloc", String(ESP.getMaxAllocHeap()));
     if (NetworkSettings.NetworkMode() == network_mode::WiFi) {
         MqttSettings.publish("dtu/rssi", String(WiFi.RSSI()));
         MqttSettings.publish("dtu/bssid", WiFi.BSSIDstr());

--- a/src/MqttHandleHass.cpp
+++ b/src/MqttHandleHass.cpp
@@ -61,6 +61,11 @@ void MqttHandleHassClass::publishConfig()
     publishDtuSensor("IP", "", "diagnostic", "mdi:network-outline", "", "");
     publishDtuSensor("WiFi Signal", "signal_strength", "diagnostic", "", "dBm", "rssi");
     publishDtuSensor("Uptime", "duration", "diagnostic", "", "s", "");
+    publishDtuSensor("Temperature", "temperature", "diagnostic", "mdi:thermometer", "°C", "temperature");
+    publishDtuSensor("Heap Size", "", "diagnostic", "mdi:memory", "Bytes", "heap/size");
+    publishDtuSensor("Heap Free", "", "diagnostic", "mdi:memory", "Bytes", "heap/free");
+    publishDtuSensor("Largest Free Heap Block", "", "diagnostic", "mdi:memory", "Bytes", "heap/maxalloc`");
+    publishDtuSensor("Lifetime Minimum Free Heap", "", "diagnostic", "mdi:memory", "Bytes", "heap/minfree`");
     publishDtuBinarySensor("Status", "connectivity", "diagnostic", config.Mqtt.Lwt.Value_Online, config.Mqtt.Lwt.Value_Offline, config.Mqtt.Lwt.Topic);
 
     yield();

--- a/src/MqttHandleHass.cpp
+++ b/src/MqttHandleHass.cpp
@@ -64,8 +64,8 @@ void MqttHandleHassClass::publishConfig()
     publishDtuSensor("Temperature", "temperature", "diagnostic", "mdi:thermometer", "°C", "temperature");
     publishDtuSensor("Heap Size", "", "diagnostic", "mdi:memory", "Bytes", "heap/size");
     publishDtuSensor("Heap Free", "", "diagnostic", "mdi:memory", "Bytes", "heap/free");
-    publishDtuSensor("Largest Free Heap Block", "", "diagnostic", "mdi:memory", "Bytes", "heap/maxalloc`");
-    publishDtuSensor("Lifetime Minimum Free Heap", "", "diagnostic", "mdi:memory", "Bytes", "heap/minfree`");
+    publishDtuSensor("Largest Free Heap Block", "", "diagnostic", "mdi:memory", "Bytes", "heap/maxalloc");
+    publishDtuSensor("Lifetime Minimum Free Heap", "", "diagnostic", "mdi:memory", "Bytes", "heap/minfree");
     publishDtuBinarySensor("Status", "connectivity", "diagnostic", config.Mqtt.Lwt.Value_Online, config.Mqtt.Lwt.Value_Offline, config.Mqtt.Lwt.Topic);
 
     yield();


### PR DESCRIPTION
I noticed that some useful ESP stats are missing on the MQTT feed, so this adds:

- ESP temperature
- ESP heap stats (size, free, minFree, maxAlloc)

![image](https://github.com/user-attachments/assets/899a3f66-6b7b-4f11-97d2-cba0685de207)