### PR TITLE
Add connection check for W5500 to prevent bootloops

### DIFF
--- a/docs/DeviceProfiles/opendtu_fusion.json
+++ b/docs/DeviceProfiles/opendtu_fusion.json
@@ -243,5 +243,83 @@
             "data": 2,
             "clk": 1
         }
+    },
+    {
+        "name": "OpenDTU Fusion v2 PoE with SH1106 Display",
+        "links": [
+            {"name": "Information", "url": "https://github.com/markusdd/OpenDTUFusionDocs"}
+        ],
+        "nrf24": {
+            "miso": 48,
+            "mosi": 35,
+            "clk": 36,
+            "irq": 47,
+            "en": 38,
+            "cs": 37
+        },
+        "cmt": {
+            "clk": 6,
+            "cs": 4,
+            "fcs": 21,
+            "sdio": 5,
+            "gpio2": 3,
+            "gpio3": 8
+        },
+        "w5500": {
+            "mosi": 40,
+            "miso": 41,
+            "sclk": 39,
+            "cs": 42,
+            "int": 44,
+            "rst": 43
+        },
+        "led": {
+            "led0": 17,
+            "led1": 18
+        },
+        "display": {
+            "type": 3,
+            "data": 2,
+            "clk": 1
+        }
+    },
+    {
+        "name": "OpenDTU Fusion v2 PoE with SSD1306 Display",
+        "links": [
+            {"name": "Information", "url": "https://github.com/markusdd/OpenDTUFusionDocs"}
+        ],
+        "nrf24": {
+            "miso": 48,
+            "mosi": 35,
+            "clk": 36,
+            "irq": 47,
+            "en": 38,
+            "cs": 37
+        },
+        "cmt": {
+            "clk": 6,
+            "cs": 4,
+            "fcs": 21,
+            "sdio": 5,
+            "gpio2": 3,
+            "gpio3": 8
+        },
+        "w5500": {
+            "mosi": 40,
+            "miso": 41,
+            "sclk": 39,
+            "cs": 42,
+            "int": 44,
+            "rst": 43
+        },
+        "led": {
+            "led0": 17,
+            "led1": 18
+        },
+        "display": {
+            "type": 2,
+            "data": 2,
+            "clk": 1
+        }
     }
 ]

--- a/include/W5500.h
+++ b/include/W5500.h
@@ -2,19 +2,28 @@
 #pragma once
 
 #include <Arduino.h>
+#include <driver/spi_master.h>
 #include <esp_eth.h> // required for esp_eth_handle_t
 #include <esp_netif.h>
 
+#include <memory>
+
 class W5500 {
+private:
+    explicit W5500(spi_device_handle_t spi, gpio_num_t pin_int);
+
 public:
-    explicit W5500(int8_t pin_mosi, int8_t pin_miso, int8_t pin_sclk, int8_t pin_cs, int8_t pin_int, int8_t pin_rst);
     W5500(const W5500&) = delete;
     W5500& operator=(const W5500&) = delete;
     ~W5500();
 
+    static std::unique_ptr<W5500> setup(int8_t pin_mosi, int8_t pin_miso, int8_t pin_sclk, int8_t pin_cs, int8_t pin_int, int8_t pin_rst);
     String macAddress();
 
 private:
+    static bool connection_check_spi(spi_device_handle_t spi);
+    static bool connection_check_interrupt(gpio_num_t pin_int);
+
     esp_eth_handle_t eth_handle;
     esp_netif_t* eth_netif;
 };

--- a/platformio.ini
+++ b/platformio.ini
@@ -254,7 +254,7 @@ build_flags = ${env.build_flags}
     -DARDUINO_USB_MODE=1
     -DARDUINO_USB_CDC_ON_BOOT=1
 
-[env:opendtufusionv2_shield]
+[env:opendtufusionv2_poe]
 board = esp32-s3-devkitc-1
 upload_protocol = esp-builtin
 debug_tool = esp-builtin

--- a/src/NetworkSettings.cpp
+++ b/src/NetworkSettings.cpp
@@ -34,7 +34,11 @@ void NetworkSettingsClass::init(Scheduler& scheduler)
 
     if (PinMapping.isValidW5500Config()) {
         PinMapping_t& pin = PinMapping.get();
-        _w5500 = std::make_unique<W5500>(pin.w5500_mosi, pin.w5500_miso, pin.w5500_sclk, pin.w5500_cs, pin.w5500_int, pin.w5500_rst);
+        _w5500 = W5500::setup(pin.w5500_mosi, pin.w5500_miso, pin.w5500_sclk, pin.w5500_cs, pin.w5500_int, pin.w5500_rst);
+        if (_w5500)
+            MessageOutput.println("W5500: Connection successful");
+        else
+            MessageOutput.println("W5500: Connection error!!");
     } else if (PinMapping.isValidEthConfig()) {
         PinMapping_t& pin = PinMapping.get();
 #if ESP_ARDUINO_VERSION_MAJOR < 3


### PR DESCRIPTION
Besides some minor improvements, this PR adds a simple connection check for the W5500 before its initialization continues to prevent bootlops in case the W5500 is configured but not (properly) connected.

The check consists of reading the version of the W5500, which should always be 0x04, and checking that the interrupt line is driven high.