### PR TITLE
Remove EMAC related code for devices that don't have one

### DIFF
--- a/include/PinMapping.h
+++ b/include/PinMapping.h
@@ -12,6 +12,7 @@
 
 struct PinMapping_t {
     char name[MAPPING_NAME_STRLEN + 1];
+
     int8_t nrf24_miso;
     int8_t nrf24_mosi;
     int8_t nrf24_clk;
@@ -33,6 +34,7 @@ struct PinMapping_t {
     int8_t w5500_int;
     int8_t w5500_rst;
 
+#if CONFIG_ETH_USE_ESP32_EMAC
     int8_t eth_phy_addr;
     bool eth_enabled;
     int eth_power;
@@ -40,11 +42,14 @@ struct PinMapping_t {
     int eth_mdio;
     eth_phy_type_t eth_type;
     eth_clock_mode_t eth_clk_mode;
+#endif
+
     uint8_t display_type;
     uint8_t display_data;
     uint8_t display_clk;
     uint8_t display_cs;
     uint8_t display_reset;
+
     int8_t led[PINMAPPING_LED_COUNT];
 };
 
@@ -57,7 +62,9 @@ public:
     bool isValidNrf24Config() const;
     bool isValidCmt2300Config() const;
     bool isValidW5500Config() const;
+#if CONFIG_ETH_USE_ESP32_EMAC
     bool isValidEthConfig() const;
+#endif
 
 private:
     PinMapping_t _pinMapping;

--- a/src/NetworkSettings.cpp
+++ b/src/NetworkSettings.cpp
@@ -39,7 +39,9 @@ void NetworkSettingsClass::init(Scheduler& scheduler)
             MessageOutput.println("W5500: Connection successful");
         else
             MessageOutput.println("W5500: Connection error!!");
-    } else if (PinMapping.isValidEthConfig()) {
+    }
+#if CONFIG_ETH_USE_ESP32_EMAC
+    else if (PinMapping.isValidEthConfig()) {
         PinMapping_t& pin = PinMapping.get();
 #if ESP_ARDUINO_VERSION_MAJOR < 3
         ETH.begin(pin.eth_phy_addr, pin.eth_power, pin.eth_mdc, pin.eth_mdio, pin.eth_type, pin.eth_clk_mode);
@@ -47,6 +49,7 @@ void NetworkSettingsClass::init(Scheduler& scheduler)
         ETH.begin(pin.eth_type, pin.eth_phy_addr, pin.eth_mdc, pin.eth_mdio, pin.eth_power, pin.eth_clk_mode);
 #endif
     }
+#endif
 
     setupMode();
 

--- a/src/PinMapping.cpp
+++ b/src/PinMapping.cpp
@@ -108,6 +108,8 @@
 #define W5500_RST -1
 #endif
 
+#if CONFIG_ETH_USE_ESP32_EMAC
+
 #ifndef ETH_PHY_ADDR
 #define ETH_PHY_ADDR -1
 #endif
@@ -130,6 +132,8 @@
 
 #ifndef ETH_CLK_MODE
 #define ETH_CLK_MODE ETH_CLOCK_GPIO0_IN
+#endif
+
 #endif
 
 PinMappingClass PinMapping;
@@ -158,18 +162,19 @@ PinMappingClass::PinMappingClass()
     _pinMapping.w5500_int = W5500_INT;
     _pinMapping.w5500_rst = W5500_RST;
 
+#if CONFIG_ETH_USE_ESP32_EMAC
 #ifdef OPENDTU_ETHERNET
     _pinMapping.eth_enabled = true;
 #else
     _pinMapping.eth_enabled = false;
 #endif
-
     _pinMapping.eth_phy_addr = ETH_PHY_ADDR;
     _pinMapping.eth_power = ETH_PHY_POWER;
     _pinMapping.eth_mdc = ETH_PHY_MDC;
     _pinMapping.eth_mdio = ETH_PHY_MDIO;
     _pinMapping.eth_type = ETH_PHY_TYPE;
     _pinMapping.eth_clk_mode = ETH_CLK_MODE;
+#endif
 
     _pinMapping.display_type = DISPLAY_TYPE;
     _pinMapping.display_data = DISPLAY_DATA;
@@ -226,18 +231,19 @@ bool PinMappingClass::init(const String& deviceMapping)
             _pinMapping.w5500_int = doc[i]["w5500"]["int"] | W5500_INT;
             _pinMapping.w5500_rst = doc[i]["w5500"]["rst"] | W5500_RST;
 
+#if CONFIG_ETH_USE_ESP32_EMAC
 #ifdef OPENDTU_ETHERNET
             _pinMapping.eth_enabled = doc[i]["eth"]["enabled"] | true;
 #else
             _pinMapping.eth_enabled = doc[i]["eth"]["enabled"] | false;
 #endif
-
             _pinMapping.eth_phy_addr = doc[i]["eth"]["phy_addr"] | ETH_PHY_ADDR;
             _pinMapping.eth_power = doc[i]["eth"]["power"] | ETH_PHY_POWER;
             _pinMapping.eth_mdc = doc[i]["eth"]["mdc"] | ETH_PHY_MDC;
             _pinMapping.eth_mdio = doc[i]["eth"]["mdio"] | ETH_PHY_MDIO;
             _pinMapping.eth_type = doc[i]["eth"]["type"] | ETH_PHY_TYPE;
             _pinMapping.eth_clk_mode = doc[i]["eth"]["clk_mode"] | ETH_CLK_MODE;
+#endif
 
             _pinMapping.display_type = doc[i]["display"]["type"] | DISPLAY_TYPE;
             _pinMapping.display_data = doc[i]["display"]["data"] | DISPLAY_DATA;
@@ -283,9 +289,11 @@ bool PinMappingClass::isValidW5500Config() const
         && _pinMapping.w5500_rst >= 0;
 }
 
+#if CONFIG_ETH_USE_ESP32_EMAC
 bool PinMappingClass::isValidEthConfig() const
 {
     return _pinMapping.eth_enabled
         && _pinMapping.eth_mdc >= 0
         && _pinMapping.eth_mdio >= 0;
 }
+#endif

--- a/src/WebApi_device.cpp
+++ b/src/WebApi_device.cpp
@@ -58,6 +58,7 @@ void WebApiDeviceClass::onDeviceAdminGet(AsyncWebServerRequest* request)
     w5500PinObj["int"] = pin.w5500_int;
     w5500PinObj["rst"] = pin.w5500_rst;
 
+#if CONFIG_ETH_USE_ESP32_EMAC
     auto ethPinObj = curPin["eth"].to<JsonObject>();
     ethPinObj["enabled"] = pin.eth_enabled;
     ethPinObj["phy_addr"] = pin.eth_phy_addr;
@@ -66,6 +67,7 @@ void WebApiDeviceClass::onDeviceAdminGet(AsyncWebServerRequest* request)
     ethPinObj["mdio"] = pin.eth_mdio;
     ethPinObj["type"] = pin.eth_type;
     ethPinObj["clk_mode"] = pin.eth_clk_mode;
+#endif
 
     auto displayPinObj = curPin["display"].to<JsonObject>();
     displayPinObj["type"] = pin.display_type;


### PR DESCRIPTION
It does not make sense to be able to configure Ethernet via the internal EMAC for targets other than the "original" ESP32, as they don't have one! Devices from the ESP32-C or ESP32-S series only support Ethernet via an external MAC, like the W5500. Therefore, the user should not be able to configure it and neither should see it in the pin configuration on the "Device-Manager" page of the OpenDTU web interface.

Furthermore, the usage of `ETH_PHY_LAN8720` in the `PinMappingClass` caused a compilation error when using Arduino core v3.0, because with v3.0 the definition only exists for targets where internal EMAC support is configured (see [`ETH.h`](https://github.com/espressif/arduino-esp32/blob/0a554933d0304b4d6a5a05f5762f5ce7368cc70e/libraries/Ethernet/src/ETH.h#L101)).