### PR TITLE
Don't set TX timeout to 0 anymore for HW/USB CDC

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -43,10 +43,8 @@ void setup()
 
     // Initialize serial output
     Serial.begin(SERIAL_BAUDRATE);
-#if ARDUINO_USB_CDC_ON_BOOT
-    Serial.setTxTimeoutMs(0);
-    delay(100);
-#else
+#if !ARDUINO_USB_CDC_ON_BOOT
+    // Only wait for serial interface to be set up when not using CDC
     while (!Serial)
         yield();
 #endif


### PR DESCRIPTION
Due to a change in the Espressif Arduino core, the TX timeout for the HW CDC (used in the ESP32-S3, for example) must not be set to 0, as otherwise, an integer underflow occurs (see [here](https://github.com/espressif/arduino-esp32/blame/43016390510e23422b0abcf432ceef2479a05f41/cores/esp32/HWCDC.cpp#L459)).

Removing the TX timeout is not necessary anymore anyways, because it is now detected when CDC is not active, and attempts to write will return immediately until the host read something again. Only when the transmit buffer becomes full initially, the default timeout of just 100ms takes effect once (and that is actually a good thing, because it prevents text from being swallowed unintentionally, when someone is actually using CDC).

For USB CDC (used with the ESP32-S2, for example), the timeout is not relevant either, although I could not test that myself.

This fixes an issue where OpenDTU won't fully boot on the ESP32-S3, unless CDC is used. Although I'm not sure yet why the issue sometimes occurs and sometimes not, I was relatively consistently able to reproduce the issue when using the latest `esptool` on Linux (Debian 12, Linux kernel v6.1) to reset the ESP32-S3: `esptool --chip esp32s3 read_flash --flash_size detect 0x0 0x1000 /dev/null`