### PR TITLE
Fix: skip BOM in JSON files (pin_mapping and config)

### DIFF
--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -160,6 +160,13 @@ bool ConfigurationClass::read()
 {
     File f = LittleFS.open(CONFIG_FILENAME, "r", false);
 
+    // skip Byte Order Mask (BOM). valid JSON docs always start with '{' or '['.
+    while (f.available() > 0) {
+        int c = f.peek();
+        if (c == '{' || c == '[') { break; }
+        f.read();
+    }
+
     JsonDocument doc;
 
     // Deserialize the JSON document

--- a/src/PinMapping.cpp
+++ b/src/PinMapping.cpp
@@ -199,6 +199,13 @@ bool PinMappingClass::init(const String& deviceMapping)
         return false;
     }
 
+    // skip Byte Order Mask (BOM). valid JSON docs always start with '{' or '['.
+    while (f.available() > 0) {
+        int c = f.peek();
+        if (c == '{' || c == '[') { break; }
+        f.read();
+    }
+
     JsonDocument doc;
     // Deserialize the JSON document
     DeserializationError error = deserializeJson(doc, f);


### PR DESCRIPTION
For obvious reasons (I guess).

See hoylabs#1355.