### PR TITLE
Add ready to use configuration for Olimex ESP32-POE-ISO Rev. L with CMT2300A

### DIFF
--- a/docs/DeviceProfiles/olimex_esp32_poe_iso_rev_L_cmt2300a.json
+++ b/docs/DeviceProfiles/olimex_esp32_poe_iso_rev_L_cmt2300a.json
@@ -1,0 +1,28 @@
+[
+    {
+        "name": "Olimex ESP32-POE-ISO with CMT2300A",
+        "_comment": "Ensure you obtain the ISO version of the Olimex ESP32 board. The board supports Power over Ethernet (PoE) and provides a wired Ethernet network connection. The CMT2300A module requires only six wires for proper functionality, not eight. In this configuration, no capacitor is necessary."},
+        "links": [
+            {"name": "Datasheet", "url": "https://www.olimex.com/Products/IoT/ESP32/ESP32-POE/open-source-hardware"},
+            {"name": "Datasheet", "url": "https://shop.blinkyparts.com/de/Ebyte-Funkmodul-CMT2300A-868-915MHz-Breakoutboard/blink238542.4",
+                "_comment": "Obtain the soldered version unless you are highly experienced with SMD soldering, as it is not suitable for beginners."}
+        ],
+        "cmt": {
+            "clk": 14,
+            "cs": 5,
+            "fcs": 15,
+            "sdio": 2,
+            "gpio2": -1,
+            "gpio3": -1
+        },
+        "eth": {
+            "enabled": true,
+            "phy_addr": 0,
+            "power": 12,
+            "mdc": 23,
+            "mdio": 18,
+            "type": 0,
+            "clk_mode": 3
+        }
+    }
+]


### PR DESCRIPTION
Hello,

maybe this is trivial to experts here, but as beginners some friends and I struggled quite a bit to find an example for this combination of Olimex ESP32-POE-ISO with CMT2300A.

Here's my working solution with some extra comments.

I think it would benefit others if it were available within the official project.

Best,
Matthias