### PR TITLE
fix: Make sure limit values sre consistent and not above 100%

### DIFF
--- a/lib/Hoymiles/src/parser/SystemConfigParaParser.cpp
+++ b/lib/Hoymiles/src/parser/SystemConfigParaParser.cpp
@@ -47,7 +47,11 @@ float SystemConfigParaParser::getLimitPercent() const
     HOY_SEMAPHORE_TAKE();
     const float ret = ((static_cast<uint16_t>(_payload[2]) << 8) | _payload[3]) / 10.0;
     HOY_SEMAPHORE_GIVE();
-    return ret;
+
+    // don't pretend the inverter could produce more than its rated power,
+    // even though it does process, accept, and even save limit values beyond
+    // its rated power.
+    return min<float>(100, ret);
 }
 
 void SystemConfigParaParser::setLimitPercent(const float value)


### PR DESCRIPTION
- Fix #2511 

fix: Make sure limit values sre consistent and not above 100%
Ref: https://github.com/tbnobody/OpenDTU/issues/25