### PR TITLE
Fix Home Assistant Energy Management

### DIFF
--- a/include/MqttAvailableHandler.h
+++ b/include/MqttAvailableHandler.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "Arduino.h"
+#include <functional>
+
+typedef std::function<void()> MqttSendData;
+
+class MqttAvailableHandler {
+public:
+    explicit MqttAvailableHandler(MqttSendData sendDataFunction);
+    
+    void send(const String &availableSubTopic, bool isAvailable);
+    void onMqttPublished(uint16_t messageId);
+private:
+    MqttSendData _MqttSendData;
+
+    uint16_t _unavailableMessageId = 0;
+};

--- a/include/MqttHandleHass.h
+++ b/include/MqttHandleHass.h
@@ -82,8 +82,8 @@ private:
     static void publishInverterBinarySensor(std::shared_ptr<InverterAbstract> inv, const String& name, const String& state_topic, const String& payload_on, const String& payload_off, const DeviceClassType device_class, const StateClassType state_class, const CategoryType category);
 
     // Sensor
-    static void publishSensor(JsonDocument& doc, const String& root_device, const String& unique_id_prefix, const String& name, const String& state_topic, const String& unit_of_measure, const String& icon, const DeviceClassType device_class, const StateClassType state_class, const CategoryType category);
-    static void publishDtuSensor(const String& name, const String& state_topic, const String& unit_of_measure, const String& icon, const DeviceClassType device_class, const StateClassType state_class, const CategoryType category);
+    static void publishSensor(JsonDocument& doc, const String& root_device, const String& unique_id_prefix, const String& name, const String& state_topic, const String& unit_of_measure, const String& icon, const DeviceClassType device_class, const StateClassType state_class, const CategoryType category, const String& extra_availability_topic = "");
+    static void publishDtuSensor(const String& name, const String& state_topic, const String& unit_of_measure, const String& icon, const DeviceClassType device_class, const StateClassType state_class, const CategoryType category, const String& extra_availability_topic = "");
     static void publishInverterSensor(std::shared_ptr<InverterAbstract> inv, const String& name, const String& state_topic, const String& unit_of_measure, const String& icon, const DeviceClassType device_class, const StateClassType state_class, const CategoryType category);
 
     static void publishInverterField(std::shared_ptr<InverterAbstract> inv, const ChannelType_t type, const ChannelNum_t channel, const byteAssign_fieldDeviceClass_t fieldType, const bool clear = false);

--- a/include/MqttHandleInverterTotal.h
+++ b/include/MqttHandleInverterTotal.h
@@ -2,6 +2,8 @@
 #pragma once
 
 #include <TaskSchedulerDeclarations.h>
+#include "MqttAvailableHandler.h"
+#include <memory>
 
 class MqttHandleInverterTotalClass {
 public:
@@ -10,10 +12,11 @@ public:
 
 private:
     void loop();
+    bool isDataValid();
+    void sendData();
 
     Task _loopTask;
-
-    unsigned int _connected_iterations = 0;
+    std::unique_ptr<MqttAvailableHandler> _availableHandler;
 };
 
 extern MqttHandleInverterTotalClass MqttHandleInverterTotal;

--- a/include/MqttHandleInverterTotal.h
+++ b/include/MqttHandleInverterTotal.h
@@ -12,6 +12,8 @@ private:
     void loop();
 
     Task _loopTask;
+
+    unsigned int _connected_iterations = 0;
 };
 
 extern MqttHandleInverterTotalClass MqttHandleInverterTotal;

--- a/include/MqttSettings.h
+++ b/include/MqttSettings.h
@@ -7,14 +7,17 @@
 #include <espMqttClient.h>
 #include <mutex>
 
+typedef std::function<void(uint16_t packetId)> MqttOnPublishCallback;
+typedef uint16_t PacketId;
+
 class MqttSettingsClass {
 public:
     MqttSettingsClass();
     void init();
     void performReconnect();
     bool getConnected();
-    void publish(const String& subtopic, const String& payload);
-    void publishGeneric(const String& topic, const String& payload, const bool retain, const uint8_t qos = 0);
+    PacketId publish(const String& subtopic, const String& payload, const uint8_t qos = 0);
+    PacketId publishGeneric(const String& topic, const String& payload, const bool retain, const uint8_t qos = 0);
 
     void subscribe(const String& topic, const uint8_t qos, const espMqttClientTypes::OnMessageCallback& cb);
     void unsubscribe(const String& topic);
@@ -22,12 +25,15 @@ public:
     String getPrefix() const;
     String getClientId() const;
 
+    void addOnPublishCallback(MqttOnPublishCallback callback);
+
 private:
     void NetworkEvent(network_event event);
 
     void onMqttDisconnect(espMqttClientTypes::DisconnectReason reason);
     void onMqttConnect(const bool sessionPresent);
     void onMqttMessage(const espMqttClientTypes::MessageProperties& properties, const char* topic, const uint8_t* payload, const size_t len, const size_t index, const size_t total);
+    void onMqttPublish(PacketId packetId);
 
     void performConnect();
     void performDisconnect();
@@ -38,6 +44,8 @@ private:
     Ticker _mqttReconnectTimer;
     MqttSubscribeParser _mqttSubscribeParser;
     std::mutex _clientLock;
+    MqttOnPublishCallback _onPacketCallback;
+    
 };
 
 extern MqttSettingsClass MqttSettings;

--- a/include/SunPosition.h
+++ b/include/SunPosition.h
@@ -15,6 +15,7 @@ public:
     bool sunsetTime(struct tm* info) const;
     bool sunriseTime(struct tm* info) const;
     void setDoRecalc(const bool doRecalc);
+    bool wasAroundSunset(unsigned long millis);
 
 private:
     void loop();
@@ -27,6 +28,8 @@ private:
     bool _isSunsetAvailable = true;
     uint32_t _sunriseMinutes = 0;
     uint32_t _sunsetMinutes = 0;
+
+    unsigned long _sunsetMillis = 0;
 
     bool _isValidInfo = false;
     std::atomic_bool _doRecalc = true;

--- a/lib/Hoymiles/src/inverters/InverterAbstract.cpp
+++ b/lib/Hoymiles/src/inverters/InverterAbstract.cpp
@@ -74,7 +74,7 @@ bool InverterAbstract::isProducing()
 
 bool InverterAbstract::isReachable()
 {
-    return _enablePolling && Statistics()->getRxFailureCount() <= _reachableThreshold;
+    return _enablePolling && Statistics()->getRxFailureCount() <= _reachableThreshold && Statistics()->getLastUpdate() > 0;
 }
 
 void InverterAbstract::setEnablePolling(const bool enabled)

--- a/src/Datastore.cpp
+++ b/src/Datastore.cpp
@@ -5,6 +5,7 @@
 #include "Datastore.h"
 #include "Configuration.h"
 #include <Hoymiles.h>
+#include <SunPosition.h>
 
 DatastoreClass Datastore;
 
@@ -25,6 +26,8 @@ void DatastoreClass::loop()
         _loopTask.forceNextIteration();
         return;
     }
+
+    const bool isDayPeriod = SunPosition.isDayPeriod();
 
     uint8_t isProducing = 0;
     uint8_t isReachable = 0;
@@ -73,29 +76,29 @@ void DatastoreClass::loop()
             }
         }
 
-        if (inv->isReachable()) {
-            isReachable++;
-        } else {
-            if (cfg->Poll_Enable) {
-                _isAllEnabledReachable = false;
-            }
-        }
-
+        float inverterYieldTotal = 0;
         for (auto& c : inv->Statistics()->getChannelsByType(TYPE_INV)) {
             if (cfg->Poll_Enable) {
-                _totalAcYieldTotalEnabled += inv->Statistics()->getChannelFieldValue(TYPE_INV, c, FLD_YT);
+                inverterYieldTotal += inv->Statistics()->getChannelFieldValue(TYPE_INV, c, FLD_YT);
                 _totalAcYieldDayEnabled += inv->Statistics()->getChannelFieldValue(TYPE_INV, c, FLD_YD);
 
                 _totalAcYieldTotalDigits = max<unsigned int>(_totalAcYieldTotalDigits, inv->Statistics()->getChannelFieldDigits(TYPE_INV, c, FLD_YT));
                 _totalAcYieldDayDigits = max<unsigned int>(_totalAcYieldDayDigits, inv->Statistics()->getChannelFieldDigits(TYPE_INV, c, FLD_YD));
             }
         }
+        _totalAcYieldTotalEnabled += inverterYieldTotal;
 
+        float inverterAcPower = 0;
         for (auto& c : inv->Statistics()->getChannelsByType(TYPE_AC)) {
+            if (cfg->Poll_Enable) {
+                inverterAcPower += inv->Statistics()->getChannelFieldValue(TYPE_AC, c, FLD_PAC);
+            }
             if (inv->getEnablePolling()) {
-                _totalAcPowerEnabled += inv->Statistics()->getChannelFieldValue(TYPE_AC, c, FLD_PAC);
                 _totalAcPowerDigits = max<unsigned int>(_totalAcPowerDigits, inv->Statistics()->getChannelFieldDigits(TYPE_AC, c, FLD_PAC));
             }
+        }
+        if (inv->getEnablePolling()) {
+            _totalAcPowerEnabled += inverterAcPower;
         }
 
         for (auto& c : inv->Statistics()->getChannelsByType(TYPE_DC)) {
@@ -106,6 +109,24 @@ void DatastoreClass::loop()
                 if (inv->Statistics()->getStringMaxPower(c) > 0) {
                     _totalDcPowerIrradiation += inv->Statistics()->getChannelFieldValue(TYPE_DC, c, FLD_PDC);
                     _totalDcIrradiationInstalled += inv->Statistics()->getStringMaxPower(c);
+                }
+            }
+        }
+
+        if (inv->isReachable()) {
+            isReachable++;
+        } else {
+            if (inv->getEnablePolling()) {
+                _isAllEnabledReachable = false;
+            }
+            if(cfg->Poll_Enable && !isDayPeriod && !cfg->Poll_Enable_Night) {
+                // enabled, but we are not polling because we are at night
+                // such inverters still count as "working properly" as long as we have valid data from sunset
+                // at sunset, we expect low power, but nonzero YieldTotal
+
+                if(inv->Statistics()->getLastUpdate() == 0 || inverterYieldTotal < 1 || inverterAcPower > 1 || !SunPosition.wasAroundSunset(inv->Statistics()->getLastUpdate())) {
+                    // no valid data -> unreachable
+                    _isAllEnabledReachable = false;
                 }
             }
         }

--- a/src/Datastore.cpp
+++ b/src/Datastore.cpp
@@ -76,7 +76,7 @@ void DatastoreClass::loop()
         if (inv->isReachable()) {
             isReachable++;
         } else {
-            if (inv->getEnablePolling()) {
+            if (cfg->Poll_Enable) {
                 _isAllEnabledReachable = false;
             }
         }

--- a/src/MqttAvailableHandler.cpp
+++ b/src/MqttAvailableHandler.cpp
@@ -1,0 +1,26 @@
+#include "MqttAvailableHandler.h"
+#include "MqttSettings.h"
+
+MqttAvailableHandler::MqttAvailableHandler(MqttSendData sendDataFunction): _MqttSendData(sendDataFunction) {
+    using std::placeholders::_1;
+    MqttSettings.addOnPublishCallback(std::bind(&MqttAvailableHandler::onMqttPublished, this, _1));
+}
+
+void MqttAvailableHandler::send(const String &availableSubTopic, bool isAvailable) {
+    if(isAvailable) {
+        this->_unavailableMessageId = 0;
+        this->_MqttSendData();
+        MqttSettings.publish(availableSubTopic, String(isAvailable));
+    } else {
+        this->_unavailableMessageId = MqttSettings.publish(availableSubTopic, String(isAvailable), 1);
+    }
+}
+
+void MqttAvailableHandler::onMqttPublished(uint16_t messageId) {
+    if(this->_unavailableMessageId > 1 && messageId == this->_unavailableMessageId) {
+        // unavailable message was successfully published
+
+        // we can now publish our invalid data safely
+        this->_MqttSendData();
+    }
+}

--- a/src/MqttHandleHass.cpp
+++ b/src/MqttHandleHass.cpp
@@ -67,8 +67,8 @@ void MqttHandleHassClass::publishConfig()
     publishDtuSensor("Largest Free Heap Block", "dtu/heap/maxalloc", "Bytes", "mdi:memory", DEVICE_CLS_NONE, STATE_CLS_NONE, CATEGORY_DIAGNOSTIC);
     publishDtuSensor("Lifetime Minimum Free Heap", "dtu/heap/minfree", "Bytes", "mdi:memory", DEVICE_CLS_NONE, STATE_CLS_NONE, CATEGORY_DIAGNOSTIC);
 
-    publishDtuSensor("Yield Total", "ac/yieldtotal", "kWh", "", DEVICE_CLS_ENERGY, STATE_CLS_TOTAL_INCREASING, CATEGORY_NONE);
-    publishDtuSensor("Yield Day", "ac/yieldday", "Wh", "", DEVICE_CLS_ENERGY, STATE_CLS_TOTAL_INCREASING, CATEGORY_NONE);
+    publishDtuSensor("Yield Total", "ac/yieldtotal", "kWh", "", DEVICE_CLS_ENERGY, STATE_CLS_TOTAL_INCREASING, CATEGORY_NONE, "ac/is_valid");
+    publishDtuSensor("Yield Day", "ac/yieldday", "Wh", "", DEVICE_CLS_ENERGY, STATE_CLS_TOTAL_INCREASING, CATEGORY_NONE, "ac/is_valid");
     publishDtuSensor("AC Power", "ac/power", "W", "", DEVICE_CLS_PWR, STATE_CLS_MEASUREMENT, CATEGORY_NONE);
     publishDtuSensor("DC Power", "dc/power", "W", "", DEVICE_CLS_PWR, STATE_CLS_MEASUREMENT, CATEGORY_NONE);  
 
@@ -165,6 +165,15 @@ void MqttHandleHassClass::publishInverterField(std::shared_ptr<InverterAbstract>
         if (Configuration.get().Mqtt.Hass.Expire) {
             root["exp_aft"] = Hoymiles.getNumInverters() * max<uint32_t>(Hoymiles.PollInterval(), Configuration.get().Mqtt.PublishInterval) * inv->getReachableThreshold();
         }
+
+        const CONFIG_T& config = Configuration.get();
+        root["avty_mode"] = "all";
+        root["avty"][0]["t"] = MqttSettings.getPrefix() + config.Mqtt.Lwt.Topic;
+        root["avty"][0]["pl_avail"] = config.Mqtt.Lwt.Value_Online;
+        root["avty"][0]["pl_not_avail"] = config.Mqtt.Lwt.Value_Offline;
+        root["avty"][1]["t"] = MqttSettings.getPrefix() + serial + "/" + "status/reachable";
+        root["avty"][1]["pl_avail"] = "1";
+        root["avty"][1]["pl_not_avail"] = "0";
 
         publish(configTopic, root);
     } else {
@@ -378,7 +387,7 @@ void MqttHandleHassClass::publishSensor(
     JsonDocument& doc,
     const String& root_device, const String& unique_id_prefix, const String& name, const String& state_topic,
     const String& unit_of_measure, const String& icon,
-    const DeviceClassType device_class, const StateClassType state_class, const CategoryType category)
+    const DeviceClassType device_class, const StateClassType state_class, const CategoryType category, const String& extra_availability_topic)
 {
     String sensor_id = name;
     sensor_id.toLowerCase();
@@ -391,9 +400,16 @@ void MqttHandleHassClass::publishSensor(
     addCommonMetadata(doc, unit_of_measure, icon, device_class, state_class, category);
 
     const CONFIG_T& config = Configuration.get();
-    doc["avty_t"] = MqttSettings.getPrefix() + config.Mqtt.Lwt.Topic;
-    doc["pl_avail"] = config.Mqtt.Lwt.Value_Online;
-    doc["pl_not_avail"] = config.Mqtt.Lwt.Value_Offline;
+    doc["avty_mode"] = "all";
+    doc["avty"][0]["t"] = MqttSettings.getPrefix() + config.Mqtt.Lwt.Topic;
+    doc["avty"][0]["pl_avail"] = config.Mqtt.Lwt.Value_Online;
+    doc["avty"][0]["pl_not_avail"] = config.Mqtt.Lwt.Value_Offline;
+    if (extra_availability_topic.length() > 0) {
+        doc["avty"][1]["t"] = MqttSettings.getPrefix() + extra_availability_topic;
+        doc["avty"][1]["pl_avail"] = "1";
+        doc["avty"][1]["pl_not_avail"] = "0";
+    }
+
 
     const String configTopic = "sensor/" + root_device + "/" + sensor_id + "/config";
     publish(configTopic, doc);
@@ -402,13 +418,13 @@ void MqttHandleHassClass::publishSensor(
 void MqttHandleHassClass::publishDtuSensor(
     const String& name, const String& state_topic,
     const String& unit_of_measure, const String& icon,
-    const DeviceClassType device_class, const StateClassType state_class, const CategoryType category)
+    const DeviceClassType device_class, const StateClassType state_class, const CategoryType category, const String& extra_availability_topic)
 {
     const String dtuId = getDtuUniqueId();
 
     JsonDocument root;
     createDtuInfo(root);
-    publishSensor(root, dtuId, dtuId, name, state_topic, unit_of_measure, icon, device_class, state_class, category);
+    publishSensor(root, dtuId, dtuId, name, state_topic, unit_of_measure, icon, device_class, state_class, category, extra_availability_topic);
 }
 
 void MqttHandleHassClass::publishInverterSensor(

--- a/src/MqttHandleInverterTotal.cpp
+++ b/src/MqttHandleInverterTotal.cpp
@@ -13,14 +13,27 @@ MqttHandleInverterTotalClass MqttHandleInverterTotal;
 MqttHandleInverterTotalClass::MqttHandleInverterTotalClass()
     : _loopTask(TASK_IMMEDIATE, TASK_FOREVER, std::bind(&MqttHandleInverterTotalClass::loop, this))
 {
+    _availableHandler.reset(new MqttAvailableHandler(std::bind(&MqttHandleInverterTotalClass::sendData, this)));
 }
 
 void MqttHandleInverterTotalClass::init(Scheduler& scheduler)
 {
-    this->_connected_iterations = 0;
     scheduler.addTask(_loopTask);
     _loopTask.setInterval(Configuration.get().Mqtt.PublishInterval * TASK_SECOND);
     _loopTask.enable();
+}
+
+bool MqttHandleInverterTotalClass::isDataValid() {
+    return Datastore.getIsAllEnabledReachable() && Datastore.getIsAtLeastOneReachable();
+}
+
+void MqttHandleInverterTotalClass::sendData() {
+    MqttSettings.publish("ac/power", String(Datastore.getTotalAcPowerEnabled(), Datastore.getTotalAcPowerDigits()));
+    MqttSettings.publish("ac/yieldtotal", String(Datastore.getTotalAcYieldTotalEnabled(), Datastore.getTotalAcYieldTotalDigits()));
+    MqttSettings.publish("ac/yieldday", String(Datastore.getTotalAcYieldDayEnabled(), Datastore.getTotalAcYieldDayDigits()));
+    MqttSettings.publish("dc/power", String(Datastore.getTotalDcPowerEnabled(), Datastore.getTotalDcPowerDigits()));
+    MqttSettings.publish("dc/irradiation", String(Datastore.getTotalDcIrradiation(), 3));
+    MqttSettings.publish("dc/is_valid", String(this->isDataValid()));
 }
 
 void MqttHandleInverterTotalClass::loop()
@@ -28,29 +41,12 @@ void MqttHandleInverterTotalClass::loop()
     // Update interval from config
     _loopTask.setInterval(Configuration.get().Mqtt.PublishInterval * TASK_SECOND);
 
-    if (!MqttSettings.getConnected()) {
-        this->_connected_iterations = 0;
-    } else {
-        this->_connected_iterations++;
-    }
-
     if (!MqttSettings.getConnected() || !Hoymiles.isAllRadioIdle()) {
         _loopTask.forceNextIteration();
         return;
     }
 
-    if(this->_connected_iterations < 2) {
-        // publish is_valid false after connecting to ensure statistics don't get a wrong value during startup
-        MqttSettings.publish("ac/is_valid", String(false));
-        MqttSettings.publish("dc/is_valid", String(false));
-        return;
-    }
+    // publishes is_valid and calls sendData when appropriate
+    _availableHandler->send("ac/is_valid", this->isDataValid());
 
-    MqttSettings.publish("ac/power", String(Datastore.getTotalAcPowerEnabled(), Datastore.getTotalAcPowerDigits()));
-    MqttSettings.publish("ac/yieldtotal", String(Datastore.getTotalAcYieldTotalEnabled(), Datastore.getTotalAcYieldTotalDigits()));
-    MqttSettings.publish("ac/yieldday", String(Datastore.getTotalAcYieldDayEnabled(), Datastore.getTotalAcYieldDayDigits()));
-    MqttSettings.publish("ac/is_valid", String(Datastore.getIsAllEnabledReachable()));
-    MqttSettings.publish("dc/power", String(Datastore.getTotalDcPowerEnabled(), Datastore.getTotalDcPowerDigits()));
-    MqttSettings.publish("dc/irradiation", String(Datastore.getTotalDcIrradiation(), 3));
-    MqttSettings.publish("dc/is_valid", String(Datastore.getIsAllEnabledReachable()));
 }

--- a/src/MqttSettings.cpp
+++ b/src/MqttSettings.cpp
@@ -130,6 +130,7 @@ void MqttSettingsClass::performConnect()
             static_cast<espMqttClientSecure*>(_mqttClient)->onConnect(std::bind(&MqttSettingsClass::onMqttConnect, this, _1));
             static_cast<espMqttClientSecure*>(_mqttClient)->onDisconnect(std::bind(&MqttSettingsClass::onMqttDisconnect, this, _1));
             static_cast<espMqttClientSecure*>(_mqttClient)->onMessage(std::bind(&MqttSettingsClass::onMqttMessage, this, _1, _2, _3, _4, _5, _6));
+            static_cast<espMqttClientSecure*>(_mqttClient)->onPublish(std::bind(&MqttSettingsClass::onMqttPublish, this, _1));
         } else {
             static_cast<espMqttClient*>(_mqttClient)->setServer(config.Mqtt.Hostname, config.Mqtt.Port);
             static_cast<espMqttClient*>(_mqttClient)->setCredentials(config.Mqtt.Username, config.Mqtt.Password);
@@ -139,9 +140,20 @@ void MqttSettingsClass::performConnect()
             static_cast<espMqttClient*>(_mqttClient)->onConnect(std::bind(&MqttSettingsClass::onMqttConnect, this, _1));
             static_cast<espMqttClient*>(_mqttClient)->onDisconnect(std::bind(&MqttSettingsClass::onMqttDisconnect, this, _1));
             static_cast<espMqttClient*>(_mqttClient)->onMessage(std::bind(&MqttSettingsClass::onMqttMessage, this, _1, _2, _3, _4, _5, _6));
+            static_cast<espMqttClient*>(_mqttClient)->onPublish(std::bind(&MqttSettingsClass::onMqttPublish, this, _1));
         }
         _mqttClient->connect();
     }
+}
+
+void MqttSettingsClass::onMqttPublish(PacketId packageId) {
+    if (this->_onPacketCallback != nullptr) {
+        this->_onPacketCallback(packageId);
+    }
+}
+
+void MqttSettingsClass::addOnPublishCallback(MqttOnPublishCallback callback) {
+    this->_onPacketCallback = callback;
 }
 
 void MqttSettingsClass::performDisconnect()
@@ -188,7 +200,7 @@ String MqttSettingsClass::getClientId() const
     return clientId;
 }
 
-void MqttSettingsClass::publish(const String& subtopic, const String& payload)
+uint16_t MqttSettingsClass::publish(const String& subtopic, const String& payload, const uint8_t qos)
 {
     String topic = getPrefix();
     topic += subtopic;
@@ -196,16 +208,16 @@ void MqttSettingsClass::publish(const String& subtopic, const String& payload)
     String value = payload;
     value.trim();
 
-    publishGeneric(topic, value, Configuration.get().Mqtt.Retain, 0);
+    return publishGeneric(topic, value, Configuration.get().Mqtt.Retain, qos);
 }
 
-void MqttSettingsClass::publishGeneric(const String& topic, const String& payload, const bool retain, const uint8_t qos)
+uint16_t MqttSettingsClass::publishGeneric(const String& topic, const String& payload, const bool retain, const uint8_t qos)
 {
     std::lock_guard<std::mutex> lock(_clientLock);
     if (_mqttClient == nullptr) {
-        return;
+        return 0;
     }
-    _mqttClient->publish(topic.c_str(), qos, retain, payload.c_str());
+    return _mqttClient->publish(topic.c_str(), qos, retain, payload.c_str());
 }
 
 void MqttSettingsClass::init()

--- a/src/SunPosition.cpp
+++ b/src/SunPosition.cpp
@@ -77,6 +77,7 @@ void SunPositionClass::updateSunData()
         _sunsetMinutes = 0;
         _isSunsetAvailable = true;
         _isValidInfo = false;
+        _sunsetMillis = 0;
         return;
     }
 
@@ -114,11 +115,15 @@ void SunPositionClass::updateSunData()
         _sunsetMinutes = 0;
         _isSunsetAvailable = false;
         _isValidInfo = false;
+        _sunsetMillis = 0;
         return;
     }
 
     _sunriseMinutes = static_cast<int>(sunriseRaw);
     _sunsetMinutes = static_cast<int>(sunsetRaw);
+
+    const unsigned long millisAtMidnight = millis() - (timeinfo.tm_hour * 60ul + timeinfo.tm_min) * 60ul * 1000ul;
+    _sunsetMillis = millisAtMidnight + _sunsetMinutes * 60ul * 1000ul;
 
     _isSunsetAvailable = true;
     _isValidInfo = true;
@@ -150,4 +155,12 @@ bool SunPositionClass::sunsetTime(struct tm* info) const
 bool SunPositionClass::sunriseTime(struct tm* info) const
 {
     return getSunTime(info, _sunriseMinutes);
+}
+
+bool SunPositionClass::wasAroundSunset(unsigned long millis) {
+    if (_sunsetMillis==0) {
+        return false;
+    }
+    unsigned long duration_between = min(millis - _sunsetMillis, _sunsetMillis - millis);
+    return duration_between < 5 * 60 * 1000ul;
 }


### PR DESCRIPTION
YieldTotal in Home Assistant Energy Management is somewhat broken, due to YieldTotal intermittently jumping to 0 or incomplete values from a subset of inverters. This happens after reboots, especially at night, and also sometimes during connectivity issues.

This PR fixes it by introducing availability topics to most MQTT topics.
Each inverter's topics are only available if that inverter is reachable.

- The total topics `ac/yieldtotal` and `ac/yieldday` are only available when *all* inverters are reachable.
- Bugs in `isReachable()` and `isAllEnabledReachable()` are fixed.
- When connecting to MQTT, the total topics are forcefully set to `unavailable` for a few seconds. This ensures no invalid data is accidentally taken as valid. Previously, rebooting would cause `ac/yieldtotal`=0 to be published *before* `ac/is_valid` = false.