### PR TITLE
Add ready to use configuration for Olimex ESP32-POE-ISO Rev. L with C…

### DIFF
--- a/docs/DeviceProfiles/olimex_esp32_poe.json
+++ b/docs/DeviceProfiles/olimex_esp32_poe.json
@@ -105,5 +105,31 @@
             "data": 33,
             "clk": 32
         }
+    },
+    {
+	    "name": "Olimex ESP32-POE-ISO with CMT2300A",
+	    "_comment": "Ensure you obtain the ISO version of the Olimex ESP32 board. The board supports Power over Ethernet (PoE) and provides a wired Ethernet network connection. The CMT2300A module requires only six wires for proper functionality, not eight. In this configuration, no capacitor is necessary."},
+	    "links": [
+		    {"name": "Datasheet", "url": "https://www.olimex.com/Products/IoT/ESP32/ESP32-POE/open-source-hardware"},
+		    {"name": "Datasheet", "url": "https://shop.blinkyparts.com/de/Ebyte-Funkmodul-CMT2300A-868-915MHz-Breakoutboard/blink238542.4",
+			    "_comment": "Obtain the soldered version unless you are highly experienced with SMD soldering, as it is not suitable for beginners."}
+	    ],
+	    "cmt": {
+		    "clk": 14,
+		    "cs": 5,
+		    "fcs": 15,
+		    "sdio": 2,
+		    "gpio2": -1,
+		    "gpio3": -1
+	    },
+	    "eth": {
+		    "enabled": true,
+		    "phy_addr": 0,
+		    "power": 12,
+		    "mdc": 23,
+		    "mdio": 18,
+		    "type": 0,
+		    "clk_mode": 3
+	    }
     }
 ]


### PR DESCRIPTION
…MT2300A module


This replaces this pull request:
https://github.com/tbnobody/OpenDTU/pull/2465