### PR TITLE
update discord links

### DIFF
--- a/lang/el.lang.json
+++ b/lang/el.lang.json
@@ -654,7 +654,7 @@
             "ErrorReporting": "Αναφορά σφαλμάτων",
             "ErrorReportingBody": "Αναφέρετε προβλήματα χρησιμοποιώντας τη δυνατότητα που παρέχεται από το <a href=\"https://github.com/tbnobody/OpenDTU/issues\" target=\"_blank\">Github</a>",
             "Discussion": "Συζήτηση",
-            "DiscussionBody": "Συζητήστε μαζί μας στο <a href=\"https://discord.gg/WzhxEY62mB\" target=\"_blank\">Discord</a> ή στο <a href=\"https://github.com/tbnobody/OpenDTU/discussions\" target=\"_blank\">Github</a>"
+            "DiscussionBody": "Συζητήστε μαζί μας στο <a href=\"https://discord.gg/3QnqGdcq\" target=\"_blank\">Discord</a> ή στο <a href=\"https://github.com/tbnobody/OpenDTU/discussions\" target=\"_blank\">Github</a>"
         },
         "hints": {
             "RadioProblem": "Δεν ήταν δυνατή η σύνδεση σε μια διαμορφωμένη μονάδα ραδιοφώνου. Επαληθεύστε τη σύνδεση.",

--- a/lang/el.lang.json
+++ b/lang/el.lang.json
@@ -654,7 +654,7 @@
             "ErrorReporting": "Αναφορά σφαλμάτων",
             "ErrorReportingBody": "Αναφέρετε προβλήματα χρησιμοποιώντας τη δυνατότητα που παρέχεται από το <a href=\"https://github.com/tbnobody/OpenDTU/issues\" target=\"_blank\">Github</a>",
             "Discussion": "Συζήτηση",
-            "DiscussionBody": "Συζητήστε μαζί μας στο <a href=\"https://discord.gg/WzhxEY62mB\" target=\"_blank\">Discord</a> ή στο <a href=\"https://github.com/tbnobody /OpenDTU/discussions\" target=\"_blank\">Github</a>"
+            "DiscussionBody": "Συζητήστε μαζί μας στο <a href=\"https://discord.gg/WzhxEY62mB\" target=\"_blank\">Discord</a> ή στο <a href=\"https://github.com/tbnobody/OpenDTU/discussions\" target=\"_blank\">Github</a>"
         },
         "hints": {
             "RadioProblem": "Δεν ήταν δυνατή η σύνδεση σε μια διαμορφωμένη μονάδα ραδιοφώνου. Επαληθεύστε τη σύνδεση.",

--- a/lang/es.lang.json
+++ b/lang/es.lang.json
@@ -654,7 +654,7 @@
             "ErrorReporting": "Reporte de Errores",
             "ErrorReportingBody": "Por favor, informa problemas utilizando la función proporcionada por <a href=\"https://github.com/tbnobody/OpenDTU/issues\" target=\"_blank\">Github</a>",
             "Discussion": "Discusión",
-            "DiscussionBody": "Discute con nosotros en <a href=\"https://discord.gg/WzhxEY62mB\" target=\"_blank\">Discord</a> o <a href=\"https://github.com/tbnobody/OpenDTU/discussions\" target=\"_blank\">Github</a>"
+            "DiscussionBody": "Discute con nosotros en <a href=\"https://discord.gg/3QnqGdcq\" target=\"_blank\">Discord</a> o <a href=\"https://github.com/tbnobody/OpenDTU/discussions\" target=\"_blank\">Github</a>"
         },
         "hints": {
             "RadioProblem": "No se pudo conectar a un módulo de radio configurado. Por favor, verifica la conexión.",

--- a/lang/it.lang.json
+++ b/lang/it.lang.json
@@ -654,7 +654,7 @@
             "ErrorReporting": "Segnalazione Errori",
             "ErrorReportingBody": "Per favore segnala eventuali problemi utilizzando le funzionalità della piattaforma <a href=\"https://github.com/tbnobody/OpenDTU/issues\" target=\"_blank\">Github</a>",
             "Discussion": "Discussioni",
-            "DiscussionBody": "Puoi avviare una discussione con noi su <a href=\"https://discord.gg/WzhxEY62mB\" target=\"_blank\">Discord</a> o <a href=\"https://github.com/tbnobody/OpenDTU/discussions\" target=\"_blank\">Github</a>"
+            "DiscussionBody": "Puoi avviare una discussione con noi su <a href=\"https://discord.gg/3QnqGdcq\" target=\"_blank\">Discord</a> o <a href=\"https://github.com/tbnobody/OpenDTU/discussions\" target=\"_blank\">Github</a>"
         },
         "hints": {
             "RadioProblem": "Non è possibile dialogare con il modulo radio selezionato. Controlla i collegamenti alla radio.",

--- a/lang/pl.lang.json
+++ b/lang/pl.lang.json
@@ -654,7 +654,7 @@
             "ErrorReporting": "Raportowanie błędów",
             "ErrorReportingBody": "Prosimy o zgłaszanie wszelkich problemów związanych z korzystaniem z funkcji platformy <a href=\"https://github.com/tbnobody/OpenDTU/issues\" target=\"_blank\">Github</a>",
             "Discussion": "Dyskusje",
-            "DiscussionBody": "Możesz rozpocząć z nami dyskusję na <a href=\"https://discord.gg/WzhxEY62mB\" target=\"_blank\">Discord</a> o <a href=\"https://github.com/tbnobody/OpenDTU/discussions\" target=\"_blank\">Github</a>"
+            "DiscussionBody": "Możesz rozpocząć z nami dyskusję na <a href=\"https://discord.gg/3QnqGdcq\" target=\"_blank\">Discord</a> o <a href=\"https://github.com/tbnobody/OpenDTU/discussions\" target=\"_blank\">Github</a>"
         },
         "hints": {
             "RadioProblem": "Nie można komunikować się z wybranym modułem radiowym. Sprawdź połączenia z radiem.",

--- a/webapp/src/locales/de.json
+++ b/webapp/src/locales/de.json
@@ -639,7 +639,7 @@
         "ErrorReporting": "Fehlerberichte",
         "ErrorReportingBody": "Bitte melde Probleme über die Ticketverwaltung von <a href=\"https://github.com/tbnobody/OpenDTU/issues\" target=\"_blank\">Github</a>.",
         "Discussion": "Diskussion",
-        "DiscussionBody": "Diskutiere mit uns auf <a href=\"https://discord.gg/WzhxEY62mB\" target=\"_blank\">Discord</a> oder <a href=\"https://github.com/tbnobody/OpenDTU/discussions\" target=\"_blank\">Github</a>"
+        "DiscussionBody": "Diskutiere mit uns auf <a href=\"https://discord.gg/3QnqGdcq\" target=\"_blank\">Discord</a> oder <a href=\"https://github.com/tbnobody/OpenDTU/discussions\" target=\"_blank\">Github</a>"
     },
     "hints": {
         "RadioProblem": "Es konnte keine Verbindung zu einem der konfigurierten Funkmodule hergestellt werden. Bitte überprüfe die Verdrahtung.",

--- a/webapp/src/locales/en.json
+++ b/webapp/src/locales/en.json
@@ -639,7 +639,7 @@
         "ErrorReporting": "Error Reporting",
         "ErrorReportingBody": "Please report issues using the feature provided by <a href=\"https://github.com/tbnobody/OpenDTU/issues\" target=\"_blank\">Github</a>",
         "Discussion": "Discussion",
-        "DiscussionBody": "Discuss with us on <a href=\"https://discord.gg/WzhxEY62mB\" target=\"_blank\">Discord</a> or <a href=\"https://github.com/tbnobody/OpenDTU/discussions\" target=\"_blank\">Github</a>"
+        "DiscussionBody": "Discuss with us on <a href=\"https://discord.gg/3QnqGdcq\" target=\"_blank\">Discord</a> or <a href=\"https://github.com/tbnobody/OpenDTU/discussions\" target=\"_blank\">Github</a>"
     },
     "hints": {
         "RadioProblem": "Could not connect to a configured radio module. Please check the wiring.",

--- a/webapp/src/locales/fr.json
+++ b/webapp/src/locales/fr.json
@@ -621,7 +621,7 @@
         "ErrorReporting": "Rapport d'erreurs",
         "ErrorReportingBody": "Veuillez signaler les problèmes en utilisant la fonction fournie par <a href=\"https://github.com/tbnobody/OpenDTU/issues\" target=\"_blank\">Github</a>.",
         "Discussion": "Discussion",
-        "DiscussionBody": "Discutez avec nous sur <a href=\"https://discord.gg/WzhxEY62mB\" target=\"_blank\">Discord</a> ou sur <a href=\"https://github.com/tbnobody/OpenDTU/discussions\" target=\"_blank\">Github</a>"
+        "DiscussionBody": "Discutez avec nous sur <a href=\"https://discord.gg/3QnqGdcq\" target=\"_blank\">Discord</a> ou sur <a href=\"https://github.com/tbnobody/OpenDTU/discussions\" target=\"_blank\">Github</a>"
     },
     "hints": {
         "RadioProblem": "Impossible de se connecter à un module radio configuré.. Veuillez vérifier le câblage.",


### PR DESCRIPTION
the new link points directly to channel "support-opendtu" on the "hoymiles research" server.

see https://discord.com/channels/984173303147155506/1029761153615790161/1403810049985613894

also fixes the URL to the github discussions in the greek language pack (that change conflicts with changing the discord URL as it targets the same line of the JSON).