### PR TITLE
Fix security condition check

### DIFF
--- a/src/MqttHandleInverter.cpp
+++ b/src/MqttHandleInverter.cpp
@@ -73,25 +73,27 @@ void MqttHandleInverterClass::loop()
 
         if (inv->SystemConfigPara()->getLastUpdate() > 0) {
             // Limit
-            MqttSettings.publish(subtopic + "/status/limit_relative", String(inv->SystemConfigPara()->getLimitPercent()));
+            const float limitPercent = inv->SystemConfigPara()->getLimitPercent();
+            MqttSettings.publish(subtopic + "/status/limit_relative", String(limitPercent));
 
-            uint16_t maxpower = inv->DevInfo()->getMaxPower();
+            const uint16_t maxpower = inv->DevInfo()->getMaxPower();
             if (maxpower > 0) {
-                MqttSettings.publish(subtopic + "/status/limit_absolute", String(inv->SystemConfigPara()->getLimitPercent() * maxpower / 100));
+                MqttSettings.publish(subtopic + "/status/limit_absolute", String(limitPercent * maxpower / 100));
             }
         }
 
         MqttSettings.publish(subtopic + "/status/reachable", String(inv->isReachable()));
         MqttSettings.publish(subtopic + "/status/producing", String(inv->isProducing()));
 
-        if (inv->Statistics()->getLastUpdate() > 0) {
-            MqttSettings.publish(subtopic + "/status/last_update", String(std::time(0) - (millis() - inv->Statistics()->getLastUpdate()) / 1000));
+        const uint32_t lastUpdate = inv->Statistics()->getLastUpdate();
+        if (lastUpdate > 0) {
+            MqttSettings.publish(subtopic + "/status/last_update", String(std::time(0) - (millis() - lastUpdate) / 1000));
         } else {
             MqttSettings.publish(subtopic + "/status/last_update", String(0));
         }
 
         const uint32_t lastUpdateInternal = inv->Statistics()->getLastUpdateFromInternal();
-        if (inv->Statistics()->getLastUpdate() > 0 && (lastUpdateInternal != _lastPublishStats[i])) {
+        if (lastUpdate > 0 && (lastUpdateInternal != _lastPublishStats[i])) {
             _lastPublishStats[i] = lastUpdateInternal;
 
             // Loop all channels

--- a/src/WebApi_device.cpp
+++ b/src/WebApi_device.cpp
@@ -121,7 +121,8 @@ void WebApiDeviceClass::onDeviceAdminPost(AsyncWebServerRequest* request)
         return;
     }
 
-    if (root["curPin"]["name"].as<String>().length() == 0 || root["curPin"]["name"].as<String>().length() > DEV_MAX_MAPPING_NAME_STRLEN) {
+    const String curPinName = root["curPin"]["name"].as<String>();
+    if (curPinName.length() == 0 || curPinName.length() > DEV_MAX_MAPPING_NAME_STRLEN) {
         retMsg["message"] = "Pin mapping must between 1 and " STR(DEV_MAX_MAPPING_NAME_STRLEN) " characters long!";
         retMsg["code"] = WebApiError::HardwarePinMappingLength;
         retMsg["param"]["max"] = DEV_MAX_MAPPING_NAME_STRLEN;

--- a/src/WebApi_inverter.cpp
+++ b/src/WebApi_inverter.cpp
@@ -114,7 +114,8 @@ void WebApiInverterClass::onInverterAdd(AsyncWebServerRequest* request)
         return;
     }
 
-    if (root["name"].as<String>().length() == 0 || root["name"].as<String>().length() > INV_MAX_NAME_STRLEN) {
+    const String name = root["name"].as<String>();
+    if (name.length() == 0 || name.length() > INV_MAX_NAME_STRLEN) {
         retMsg["message"] = "Name must between 1 and " STR(INV_MAX_NAME_STRLEN) " characters long!";
         retMsg["code"] = WebApiError::InverterNameLength;
         retMsg["param"]["max"] = INV_MAX_NAME_STRLEN;
@@ -193,7 +194,8 @@ void WebApiInverterClass::onInverterEdit(AsyncWebServerRequest* request)
         return;
     }
 
-    if (root["name"].as<String>().length() == 0 || root["name"].as<String>().length() > INV_MAX_NAME_STRLEN) {
+    const String name = root["name"].as<String>();
+    if (name.length() == 0 || name.length() > INV_MAX_NAME_STRLEN) {
         retMsg["message"] = "Name must between 1 and " STR(INV_MAX_NAME_STRLEN) " characters long!";
         retMsg["code"] = WebApiError::InverterNameLength;
         retMsg["param"]["max"] = INV_MAX_NAME_STRLEN;

--- a/src/WebApi_mqtt.cpp
+++ b/src/WebApi_mqtt.cpp
@@ -137,7 +137,8 @@ void WebApiMqttClass::onMqttAdminPost(AsyncWebServerRequest* request)
     }
 
     if (root["mqtt_enabled"].as<bool>()) {
-        if (root["mqtt_hostname"].as<String>().length() == 0 || root["mqtt_hostname"].as<String>().length() > MQTT_MAX_HOSTNAME_STRLEN) {
+        const String mqtt_hostname = root["mqtt_hostname"].as<String>();
+        if (mqtt_hostname.length() == 0 || mqtt_hostname.length() > MQTT_MAX_HOSTNAME_STRLEN) {
             retMsg["message"] = "MqTT Server must between 1 and " STR(MQTT_MAX_HOSTNAME_STRLEN) " characters long!";
             retMsg["code"] = WebApiError::MqttHostnameLength;
             retMsg["param"]["max"] = MQTT_MAX_HOSTNAME_STRLEN;
@@ -166,7 +167,9 @@ void WebApiMqttClass::onMqttAdminPost(AsyncWebServerRequest* request)
             WebApi.sendJsonResponse(request, response, __FUNCTION__, __LINE__);
             return;
         }
-        if (root["mqtt_topic"].as<String>().length() > MQTT_MAX_TOPIC_STRLEN) {
+
+        const String mqtt_topic = root["mqtt_topic"].as<String>();
+        if (mqtt_topic.length() > MQTT_MAX_TOPIC_STRLEN) {
             retMsg["message"] = "Topic must not be longer than " STR(MQTT_MAX_TOPIC_STRLEN) " characters!";
             retMsg["code"] = WebApiError::MqttTopicLength;
             retMsg["param"]["max"] = MQTT_MAX_TOPIC_STRLEN;
@@ -174,14 +177,14 @@ void WebApiMqttClass::onMqttAdminPost(AsyncWebServerRequest* request)
             return;
         }
 
-        if (root["mqtt_topic"].as<String>().indexOf(' ') != -1) {
+        if (mqtt_topic.indexOf(' ') != -1) {
             retMsg["message"] = "Topic must not contain space characters!";
             retMsg["code"] = WebApiError::MqttTopicCharacter;
             WebApi.sendJsonResponse(request, response, __FUNCTION__, __LINE__);
             return;
         }
 
-        if (!root["mqtt_topic"].as<String>().endsWith("/")) {
+        if (!mqtt_topic.endsWith("/")) {
             retMsg["message"] = "Topic must end with a slash (/)!";
             retMsg["code"] = WebApiError::MqttTopicTrailingSlash;
             WebApi.sendJsonResponse(request, response, __FUNCTION__, __LINE__);
@@ -205,7 +208,8 @@ void WebApiMqttClass::onMqttAdminPost(AsyncWebServerRequest* request)
             return;
         }
 
-        if (root["mqtt_lwt_topic"].as<String>().length() > MQTT_MAX_TOPIC_STRLEN) {
+        const String mqtt_lwt_topic = root["mqtt_lwt_topic"].as<String>();
+        if (mqtt_lwt_topic.length() > MQTT_MAX_TOPIC_STRLEN) {
             retMsg["message"] = "LWT topic must not be longer than " STR(MQTT_MAX_TOPIC_STRLEN) " characters!";
             retMsg["code"] = WebApiError::MqttLwtTopicLength;
             retMsg["param"]["max"] = MQTT_MAX_TOPIC_STRLEN;
@@ -213,7 +217,7 @@ void WebApiMqttClass::onMqttAdminPost(AsyncWebServerRequest* request)
             return;
         }
 
-        if (root["mqtt_lwt_topic"].as<String>().indexOf(' ') != -1) {
+        if (mqtt_lwt_topic.indexOf(' ') != -1) {
             retMsg["message"] = "LWT topic must not contain space characters!";
             retMsg["code"] = WebApiError::MqttLwtTopicCharacter;
             WebApi.sendJsonResponse(request, response, __FUNCTION__, __LINE__);
@@ -244,7 +248,8 @@ void WebApiMqttClass::onMqttAdminPost(AsyncWebServerRequest* request)
             return;
         }
 
-        if (root["mqtt_publish_interval"].as<uint32_t>() < 5 || root["mqtt_publish_interval"].as<uint32_t>() > 65535) {
+        const uint32_t mqtt_publish_interval = root["mqtt_publish_interval"].as<uint32_t>();
+        if (mqtt_publish_interval < 5 || mqtt_publish_interval > 65535) {
             retMsg["message"] = "Publish interval must be a number between 5 and 65535!";
             retMsg["code"] = WebApiError::MqttPublishInterval;
             retMsg["param"]["min"] = 5;
@@ -254,7 +259,8 @@ void WebApiMqttClass::onMqttAdminPost(AsyncWebServerRequest* request)
         }
 
         if (root["mqtt_hass_enabled"].as<bool>()) {
-            if (root["mqtt_hass_topic"].as<String>().length() > MQTT_MAX_TOPIC_STRLEN) {
+            const String mqtt_hass_topic = root["mqtt_hass_topic"].as<String>();
+            if (mqtt_hass_topic.length() > MQTT_MAX_TOPIC_STRLEN) {
                 retMsg["message"] = "Hass topic must not be longer than " STR(MQTT_MAX_TOPIC_STRLEN) " characters!";
                 retMsg["code"] = WebApiError::MqttHassTopicLength;
                 retMsg["param"]["max"] = MQTT_MAX_TOPIC_STRLEN;
@@ -262,14 +268,14 @@ void WebApiMqttClass::onMqttAdminPost(AsyncWebServerRequest* request)
                 return;
             }
 
-            if (root["mqtt_hass_topic"].as<String>().indexOf(' ') != -1) {
+            if (mqtt_hass_topic.indexOf(' ') != -1) {
                 retMsg["message"] = "Hass topic must not contain space characters!";
                 retMsg["code"] = WebApiError::MqttHassTopicCharacter;
                 WebApi.sendJsonResponse(request, response, __FUNCTION__, __LINE__);
                 return;
             }
 
-            if (!root["mqtt_hass_topic"].as<String>().endsWith("/")) {
+            if (!mqtt_hass_topic.endsWith("/")) {
                 retMsg["message"] = "Hass topic must end with a slash (/)!";
                 retMsg["code"] = WebApiError::MqttHassTopicTrailingSlash;
                 WebApi.sendJsonResponse(request, response, __FUNCTION__, __LINE__);

--- a/src/WebApi_network.cpp
+++ b/src/WebApi_network.cpp
@@ -150,13 +150,15 @@ void WebApiNetworkClass::onNetworkAdminPost(AsyncWebServerRequest* request)
         return;
     }
 
-    if (root["hostname"].as<String>().length() == 0 || root["hostname"].as<String>().length() > WIFI_MAX_HOSTNAME_STRLEN) {
+    const String hostname = root["hostname"].as<String>();
+    if (hostname.length() == 0 || hostname.length() > WIFI_MAX_HOSTNAME_STRLEN) {
         retMsg["message"] = "Hostname must between 1 and " STR(WIFI_MAX_HOSTNAME_STRLEN) " characters long!";
         WebApi.sendJsonResponse(request, response, __FUNCTION__, __LINE__);
         return;
     }
     if (NetworkSettings.NetworkMode() == network_mode::WiFi) {
-        if (root["ssid"].as<String>().length() == 0 || root["ssid"].as<String>().length() > WIFI_MAX_SSID_STRLEN) {
+        const String ssid = root["ssid"].as<String>();
+        if (ssid.length() == 0 || ssid.length() > WIFI_MAX_SSID_STRLEN) {
             retMsg["message"] = "SSID must between 1 and " STR(WIFI_MAX_SSID_STRLEN) " characters long!";
             WebApi.sendJsonResponse(request, response, __FUNCTION__, __LINE__);
             return;
@@ -174,7 +176,8 @@ void WebApiNetworkClass::onNetworkAdminPost(AsyncWebServerRequest* request)
         return;
     }
     if (root["syslogenabled"].as<bool>()) {
-        if (root["sysloghostname"].as<String>().length() == 0 || root["sysloghostname"].as<String>().length() > SYSLOG_MAX_HOSTNAME_STRLEN) {
+        const String sysloghostname = root["sysloghostname"].as<String>();
+        if (sysloghostname.length() == 0 || sysloghostname.length() > SYSLOG_MAX_HOSTNAME_STRLEN) {
             retMsg["message"] = "Syslog Server must between 1 and " STR(SYSLOG_MAX_HOSTNAME_STRLEN) " characters long!";
             retMsg["code"] = WebApiError::NetworkSyslogHostnameLength;
             retMsg["param"]["max"] = SYSLOG_MAX_HOSTNAME_STRLEN;
@@ -182,7 +185,8 @@ void WebApiNetworkClass::onNetworkAdminPost(AsyncWebServerRequest* request)
             return;
         }
 
-        if (root["syslogport"].as<uint>() == 0 || root["syslogport"].as<uint>() > 65535) {
+        const uint syslogport = root["syslogport"].as<uint>();
+        if (syslogport == 0 || syslogport > 65535) {
             retMsg["message"] = "Port must be a number between 1 and 65535!";
             retMsg["code"] = WebApiError::NetworkSyslogPort;
             WebApi.sendJsonResponse(request, response, __FUNCTION__, __LINE__);

--- a/src/WebApi_ntp.cpp
+++ b/src/WebApi_ntp.cpp
@@ -111,7 +111,8 @@ void WebApiNtpClass::onNtpAdminPost(AsyncWebServerRequest* request)
         return;
     }
 
-    if (root["ntp_server"].as<String>().length() == 0 || root["ntp_server"].as<String>().length() > NTP_MAX_SERVER_STRLEN) {
+    const String ntp_server = root["ntp_server"].as<String>();
+    if (ntp_server.length() == 0 || ntp_server.length() > NTP_MAX_SERVER_STRLEN) {
         retMsg["message"] = "NTP Server must between 1 and " STR(NTP_MAX_SERVER_STRLEN) " characters long!";
         retMsg["code"] = WebApiError::NtpServerLength;
         retMsg["param"]["max"] = NTP_MAX_SERVER_STRLEN;
@@ -119,7 +120,8 @@ void WebApiNtpClass::onNtpAdminPost(AsyncWebServerRequest* request)
         return;
     }
 
-    if (root["ntp_timezone"].as<String>().length() == 0 || root["ntp_timezone"].as<String>().length() > NTP_MAX_TIMEZONE_STRLEN) {
+    const String ntp_timezone = root["ntp_timezone"].as<String>();
+    if (ntp_timezone.length() == 0 || ntp_timezone.length() > NTP_MAX_TIMEZONE_STRLEN) {
         retMsg["message"] = "Timezone must between 1 and " STR(NTP_MAX_TIMEZONE_STRLEN) " characters long!";
         retMsg["code"] = WebApiError::NtpTimezoneLength;
         retMsg["param"]["max"] = NTP_MAX_TIMEZONE_STRLEN;
@@ -127,7 +129,8 @@ void WebApiNtpClass::onNtpAdminPost(AsyncWebServerRequest* request)
         return;
     }
 
-    if (root["ntp_timezone_descr"].as<String>().length() == 0 || root["ntp_timezone_descr"].as<String>().length() > NTP_MAX_TIMEZONEDESCR_STRLEN) {
+    const String ntp_timezone_descr = root["ntp_timezone_descr"].as<String>();
+    if (ntp_timezone_descr.length() == 0 || ntp_timezone_descr.length() > NTP_MAX_TIMEZONEDESCR_STRLEN) {
         retMsg["message"] = "Timezone description must between 1 and " STR(NTP_MAX_TIMEZONEDESCR_STRLEN) " characters long!";
         retMsg["code"] = WebApiError::NtpTimezoneDescriptionLength;
         retMsg["param"]["max"] = NTP_MAX_TIMEZONEDESCR_STRLEN;

--- a/src/WebApi_security.cpp
+++ b/src/WebApi_security.cpp
@@ -56,7 +56,8 @@ void WebApiSecurityClass::onSecurityPost(AsyncWebServerRequest* request)
         return;
     }
 
-    if (root["password"].as<String>().length() < 8 || root["password"].as<String>().length() > WIFI_MAX_PASSWORD_STRLEN) {
+    const String password = root["password"].as<String>();
+    if (password.length() < 8 || password.length() > WIFI_MAX_PASSWORD_STRLEN) {
         retMsg["message"] = "Password must between 8 and " STR(WIFI_MAX_PASSWORD_STRLEN) " characters long!";
         retMsg["code"] = WebApiError::SecurityPasswordLength;
         retMsg["param"]["max"] = WIFI_MAX_PASSWORD_STRLEN;

--- a/src/WebApi_ws_live.cpp
+++ b/src/WebApi_ws_live.cpp
@@ -147,14 +147,18 @@ void WebApiWsLiveClass::generateInverterCommonJsonResponse(JsonObject& root, std
     root["serial"] = inv->serialString();
     root["name"] = inv->name();
     root["order"] = inv_cfg->Order;
-    root["data_age"] = (millis() - inv->Statistics()->getLastUpdate()) / 1000;
-    root["data_age_ms"] = millis() - inv->Statistics()->getLastUpdate();
+    const uint32_t lastUpdate = inv->Statistics()->getLastUpdate();
+    const uint32_t dataAgeMs = millis() - lastUpdate;
+    root["data_age"] = dataAgeMs / 1000;
+    root["data_age_ms"] = dataAgeMs;
     root["poll_enabled"] = inv->getEnablePolling();
     root["reachable"] = inv->isReachable();
     root["producing"] = inv->isProducing();
-    root["limit_relative"] = inv->SystemConfigPara()->getLimitPercent();
-    if (inv->DevInfo()->getMaxPower() > 0) {
-        root["limit_absolute"] = inv->SystemConfigPara()->getLimitPercent() * inv->DevInfo()->getMaxPower() / 100.0;
+    const float limitPercent = inv->SystemConfigPara()->getLimitPercent();
+    const uint16_t maxPower = inv->DevInfo()->getMaxPower();
+    root["limit_relative"] = limitPercent;
+    if (maxPower > 0) {
+        root["limit_absolute"] = limitPercent * maxPower / 100.0;
     } else {
         root["limit_absolute"] = -1;
     }


### PR DESCRIPTION
Corrected the logical condition in WebApiSecurityClass::onSecurityPost to properly handle cases where 'allow_readonly' is not a boolean. This change ensures that the security checks accurately identify missing or incorrectly formatted values, improving the robustness of the API's security posture.