### PR TITLE
Add support for HMS-2000D-4T inverters with serial prefix 0x1166

### DIFF
--- a/lib/Hoymiles/src/inverters/HMS_4CH.cpp
+++ b/lib/Hoymiles/src/inverters/HMS_4CH.cpp
@@ -58,7 +58,7 @@ bool HMS_4CH::isValidSerial(const uint64_t serial)
 {
     // serial >= 0x116400000000 && serial <= 0x1164ffffffff
     uint16_t preSerial = (serial >> 32) & 0xffff;
-    return preSerial == 0x1164 || preSerial == 0x1420;
+    return preSerial == 0x1164 || preSerial == 0x1166 || preSerial == 0x1420;
 }
 
 String HMS_4CH::typeName() const


### PR DESCRIPTION
Fixes recognition of Thai/Asian HMS-2000D-4T inverters that use serial numbers starting with 1166. Without this fix, these inverters are not properly recognized and the wrong RF module (not CMT2300A) is selected.

Tested with HMS-2000D-4T serial starting with 1166.