### PR TITLE
Fix: WebSocket endpoints missing setAuthType for digest authentication

### DIFF
--- a/src/WebApi_ws_console.cpp
+++ b/src/WebApi_ws_console.cpp
@@ -24,6 +24,7 @@ void WebApiWsConsoleClass::init(AsyncWebServer& server, Scheduler& scheduler)
 
     _simpleDigestAuth.setUsername(AUTH_USERNAME);
     _simpleDigestAuth.setRealm("console websocket");
+    _simpleDigestAuth.setAuthType(AsyncAuthType::AUTH_DIGEST);
 
     reload();
 }

--- a/src/WebApi_ws_live.cpp
+++ b/src/WebApi_ws_live.cpp
@@ -44,6 +44,7 @@ void WebApiWsLiveClass::init(AsyncWebServer& server, Scheduler& scheduler)
     _sendDataTask.enable();
     _simpleDigestAuth.setUsername(AUTH_USERNAME);
     _simpleDigestAuth.setRealm("live websocket");
+    _simpleDigestAuth.setAuthType(AsyncAuthType::AUTH_DIGEST);
 
     reload();
 }


### PR DESCRIPTION
Fixes #3007
