### PR TITLE
NRF24: use protocol-correct response channel offset after TX

### DIFF
--- a/lib/Hoymiles/src/HoymilesRadio_NRF.cpp
+++ b/lib/Hoymiles/src/HoymilesRadio_NRF.cpp
@@ -153,14 +153,14 @@ void ARDUINO_ISR_ATTR HoymilesRadio_NRF::handleIntr()
 
 uint8_t HoymilesRadio_NRF::getRxNxtChannel()
 {
-    if (++_rxChIdx >= sizeof(_rxChLst))
+    if (++_rxChIdx >= RF_CHANNELS)
         _rxChIdx = 0;
     return _rxChLst[_rxChIdx];
 }
 
 uint8_t HoymilesRadio_NRF::getTxNxtChannel()
 {
-    if (++_txChIdx >= sizeof(_txChLst))
+    if (++_txChIdx >= RF_CHANNELS)
         _txChIdx = 0;
     return _txChLst[_txChIdx];
 }
@@ -192,7 +192,10 @@ void HoymilesRadio_NRF::sendEsbPacket(CommandAbstract& cmd)
 
     _radio->setRetries(0, 0);
     openReadingPipe();
-    _radio->setChannel(getRxNxtChannel());
+
+    // Set initial RX to protocol-correct response channel: (txChIdx + 3) % 5
+    _rxChIdx = (_txChIdx + 3) % RF_CHANNELS;
+    _radio->setChannel(_rxChLst[_rxChIdx]);
     _radio->startListening();
     _busyFlag = true;
     _rxTimeout.set(cmd.getTimeout());

--- a/lib/Hoymiles/src/HoymilesRadio_NRF.h
+++ b/lib/Hoymiles/src/HoymilesRadio_NRF.h
@@ -4,6 +4,7 @@
 #include "HoymilesRadio.h"
 #include "commands/CommandAbstract.h"
 #include <RF24.h>
+#include <cstdint>
 #include <memory>
 #include <nRF24L01.h>
 #include <queue>
@@ -34,10 +35,12 @@ private:
 
     std::unique_ptr<SPIClass> _spiPtr;
     std::unique_ptr<RF24> _radio;
-    uint8_t _rxChLst[5] = { 3, 23, 40, 61, 75 };
+    static constexpr uint8_t RF_CHANNELS = 5;
+
+    uint8_t _rxChLst[RF_CHANNELS] = { 3, 23, 40, 61, 75 };
     uint8_t _rxChIdx = 0;
 
-    uint8_t _txChLst[5] = { 3, 23, 40, 61, 75 };
+    uint8_t _txChLst[RF_CHANNELS] = { 3, 23, 40, 61, 75 };
     uint8_t _txChIdx = 0;
 
     volatile bool _packetReceived = false;


### PR DESCRIPTION
After transmitting on channel index N, switch the receiver to channel (N+3) % 5 instead of the next sequential channel. This follows the Hoymiles protocol convention, where inverters respond on an offset channel.

This behavior is confirmed and has been hardware‑verified with HM‑series inverters (1CH and 2CH).

Success rate is now approximately 98%, compared to about 75% before the change.
Tested with three active inverters: HM300, HM600, HM600.
Re-Request-Rate can reach 0 % , but is not always this perfect.

At the same time, three additional inverters and an AhoyDTU are present in the area.