### PR TITLE
feat(mqtt): add DTU restart command topic

### DIFF
--- a/include/MqttHandleDtu.h
+++ b/include/MqttHandleDtu.h
@@ -3,16 +3,32 @@
 
 #include <TaskSchedulerDeclarations.h>
 #include <cstdint>
+#include <espMqttClient.h>
+#include <frozen/map.h>
+#include <frozen/string.h>
 
 class MqttHandleDtuClass {
 public:
     MqttHandleDtuClass();
     void init(Scheduler& scheduler);
 
+    void subscribeTopics();
+    void unsubscribeTopics();
+
 private:
     void loop();
+    void onMqttMessage(const espMqttClientTypes::MessageProperties& properties, const char* topic, const uint8_t* payload, const size_t len);
 
     Task _loopTask;
+
+    enum class Topic : unsigned {
+        Restart,
+    };
+
+    static constexpr frozen::string _cmdtopic = "dtu/cmd/";
+    static constexpr frozen::map<frozen::string, Topic, 1> _subscriptions = {
+        { "restart", Topic::Restart },
+    };
 };
 
 extern MqttHandleDtuClass MqttHandleDtu;

--- a/include/MqttHandleHass.h
+++ b/include/MqttHandleHass.h
@@ -79,6 +79,7 @@ private:
     // Binary Sensor
     static void publishBinarySensor(JsonDocument& doc, const String& root_device, const String& unique_id_prefix, const String& name, const String& state_topic, const String& payload_on, const String& payload_off, const DeviceClassType device_class, const StateClassType state_class, const CategoryType category);
     static void publishDtuBinarySensor(const String& name, const String& state_topic, const String& payload_on, const String& payload_off, const DeviceClassType device_class, const StateClassType state_class, const CategoryType category);
+    static void publishDtuButton(const String& name, const String& cmd_topic, const String& payload, const String& icon, const DeviceClassType device_class, const StateClassType state_class, const CategoryType category);
     static void publishInverterBinarySensor(std::shared_ptr<InverterAbstract> inv, const String& name, const String& state_topic, const String& payload_on, const String& payload_off, const DeviceClassType device_class, const StateClassType state_class, const CategoryType category);
 
     // Sensor

--- a/src/MqttHandleDtu.cpp
+++ b/src/MqttHandleDtu.cpp
@@ -6,8 +6,12 @@
 #include "Configuration.h"
 #include "MqttSettings.h"
 #include "NetworkSettings.h"
+#include "RestartHelper.h"
 #include <CpuTemperature.h>
 #include <Hoymiles.h>
+
+#undef TAG
+static const char* TAG = "mqtt";
 
 MqttHandleDtuClass MqttHandleDtu;
 
@@ -18,6 +22,8 @@ MqttHandleDtuClass::MqttHandleDtuClass()
 
 void MqttHandleDtuClass::init(Scheduler& scheduler)
 {
+    subscribeTopics();
+
     scheduler.addTask(_loopTask);
     _loopTask.setInterval(Configuration.get().Mqtt.PublishInterval * TASK_SECOND);
     _loopTask.enable();
@@ -47,5 +53,56 @@ void MqttHandleDtuClass::loop()
     float temperature = CpuTemperature.read();
     if (!std::isnan(temperature)) {
         MqttSettings.publish("dtu/temperature", String(temperature));
+    }
+}
+
+void MqttHandleDtuClass::subscribeTopics()
+{
+    String const& prefix = MqttSettings.getPrefix();
+
+    auto subscribe = [&prefix, this](char const* subTopic, Topic t) {
+        String fullTopic(prefix + _cmdtopic.data() + subTopic);
+        MqttSettings.subscribe(fullTopic.c_str(), 0,
+            std::bind(&MqttHandleDtuClass::onMqttMessage, this,
+                std::placeholders::_1, std::placeholders::_2,
+                std::placeholders::_3, std::placeholders::_4));
+    };
+
+    for (auto const& s : _subscriptions) {
+        subscribe(s.first.data(), s.second);
+    }
+}
+
+void MqttHandleDtuClass::unsubscribeTopics()
+{
+    String const& prefix = MqttSettings.getPrefix() + _cmdtopic.data();
+    for (auto const& s : _subscriptions) {
+        MqttSettings.unsubscribe(prefix + s.first.data());
+    }
+}
+
+void MqttHandleDtuClass::onMqttMessage(const espMqttClientTypes::MessageProperties& properties, const char* topic, const uint8_t* payload, const size_t len)
+{
+    std::string strValue(reinterpret_cast<const char*>(payload), len);
+    float payload_val = -1;
+    try {
+        payload_val = std::stof(strValue);
+    } catch (std::invalid_argument const& e) {
+        ESP_LOGW(TAG, "MQTT handler: cannot parse payload of topic '%s' as float: %s",
+            topic, strValue.c_str());
+        return;
+    }
+
+    // Match "dtu/cmd/restart" in the topic
+    const CONFIG_T& config = Configuration.get();
+    String restartTopic = String(config.Mqtt.Topic) + _cmdtopic.data() + "restart";
+
+    if (restartTopic == topic) {
+        ESP_LOGI(TAG, "Restart OpenDTU");
+        if (!properties.retain && payload_val == 1) {
+            RestartHelper.triggerRestart();
+        } else {
+            ESP_LOGW(TAG, "Ignored because retained or numeric value not '1'");
+        }
     }
 }

--- a/src/MqttHandleHass.cpp
+++ b/src/MqttHandleHass.cpp
@@ -82,6 +82,8 @@ void MqttHandleHassClass::publishConfig()
 
     publishDtuBinarySensor("Status", config.Mqtt.Lwt.Topic, config.Mqtt.Lwt.Value_Online, config.Mqtt.Lwt.Value_Offline, DEVICE_CLS_CONNECTIVITY, STATE_CLS_NONE, CATEGORY_DIAGNOSTIC);
 
+    publishDtuButton("Restart OpenDTU", "dtu/cmd/restart", "1", "", DEVICE_CLS_RESTART, STATE_CLS_NONE, CATEGORY_CONFIG);
+
     // Loop all inverters
     for (uint8_t i = 0; i < Hoymiles.getNumInverters(); i++) {
         auto inv = Hoymiles.getInverterByPos(i);
@@ -371,6 +373,35 @@ void MqttHandleHassClass::publishDtuBinarySensor(
     JsonDocument root;
     createDtuInfo(root);
     publishBinarySensor(root, dtuId, dtuId, name, state_topic, payload_on, payload_off, device_class, state_class, category);
+}
+
+void MqttHandleHassClass::publishDtuButton(
+    const String& name, const String& cmd_topic, const String& payload,
+    const String& icon,
+    const DeviceClassType device_class, const StateClassType state_class, const CategoryType category)
+{
+    const String dtuId = getDtuUniqueId();
+
+    String buttonId = name;
+    buttonId.replace(" ", "_");
+    buttonId.toLowerCase();
+
+    const String configTopic = "button/" + dtuId
+        + "/" + buttonId
+        + "/config";
+
+    const String fullCmdTopic = MqttSettings.getPrefix() + cmd_topic;
+
+    JsonDocument root;
+    createDtuInfo(root);
+    addCommonMetadata(root, "", icon, device_class, state_class, category);
+
+    root["name"] = name;
+    root["uniq_id"] = dtuId + "_" + buttonId;
+    root["cmd_t"] = fullCmdTopic;
+    root["payload_press"] = payload;
+
+    publish(configTopic, root);
 }
 
 void MqttHandleHassClass::publishInverterBinarySensor(


### PR DESCRIPTION
## Summary

Adds MQTT topic `<prefix>dtu/cmd/restart` to allow rebooting OpenDTU from external systems like Node-RED or Home Assistant.

## Changes

- **`MqttHandleDtu.h/cpp`**: Subscribe to `<prefix>dtu/cmd/restart`, handle incoming messages, trigger `RestartHelper.triggerRestart()` on payload `1`
- **`MqttHandleHass.h/cpp`**: Add Home Assistant auto-discovery button for DTU restart

## Usage

```
Topic:    solar/dtu/cmd/restart
Payload:  1
Retain:   false
```

## Safety

- Retained messages are ignored
- Payload must be exactly `1`
- Uses `RestartHelper` for safe shutdown (LEDs off, display off before `ESP.restart()`)

## Home Assistant

A "Restart OpenDTU" button is automatically discovered via MQTT.