### PR TITLE
fix(hoymiles): process radio queues in FIFO order

### DIFF
--- a/lib/Hoymiles/src/HoymilesRadio_CMT.cpp
+++ b/lib/Hoymiles/src/HoymilesRadio_CMT.cpp
@@ -155,7 +155,7 @@ void HoymilesRadio_CMT::loop()
     } else {
         // Perform package parsing only if no packages are received
         if (!_rxBuffer.empty()) {
-            fragment_t f = _rxBuffer.back();
+            fragment_t f = _rxBuffer.front();
             if (checkFragmentCrc(f)) {
 
                 const serial_u dtuId = convertSerialToRadioId(_dtuSerial);

--- a/lib/Hoymiles/src/HoymilesRadio_NRF.cpp
+++ b/lib/Hoymiles/src/HoymilesRadio_NRF.cpp
@@ -74,7 +74,7 @@ void HoymilesRadio_NRF::loop()
     } else {
         // Perform package parsing only if no packages are received
         if (!_rxBuffer.empty()) {
-            fragment_t f = _rxBuffer.back();
+            fragment_t f = _rxBuffer.front();
             if (checkFragmentCrc(f)) {
                 std::shared_ptr<InverterAbstract> inv = Hoymiles.getInverterByFragment(f);
 


### PR DESCRIPTION
std::queue::pop() removes the front element. Read that same element before processing so queued CMT and NRF fragments are neither skipped nor processed repeatedly.

## What this fixes

Both radio implementations store received fragments in a `std::queue`.

`push()` adds a fragment at the back of the queue, while `pop()` removes
the fragment at the front. The code previously read `back()` and then
called `pop()`, so it processed and removed different fragments whenever
more than one fragment was queued.

For a queue containing A, B and C, the previous code could:

1. process C and remove A;
2. process C again and remove B;
3. process C again and remove C.

A and B were therefore discarded without being processed.

## Change

Read `front()` https://cplusplus.com/reference/queue/queue/front/ before calling `pop()` in both radio implementations:

- CMT2300A
- NRF24

The fragment that is processed is now the same fragment that is removed.

No radio timing, protocol, retry or scheduling behaviour is changed.

This follows the request in
https://github.com/tbnobody/OpenDTU/pull/2962#issuecomment-5098204126
to provide the correction separately for both radio implementations.

## Verification

- `git diff --check`
- `generic_esp32` PlatformIO build