### PR TITLE
Bugfix: Cyclic publish state topic to prevent unavail sensors on HA

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -8,6 +8,7 @@
         "platformio.platformio-ide"
     ],
     "unwantedRecommendations": [
-        "ms-vscode.cpptools-extension-pack"
+        "ms-vscode.cpptools-extension-pack",
+        "pioarduino.pioarduino-ide"
     ]
 }

--- a/src/MqttHandleDtu.cpp
+++ b/src/MqttHandleDtu.cpp
@@ -25,12 +25,17 @@ void MqttHandleDtuClass::init(Scheduler& scheduler)
 
 void MqttHandleDtuClass::loop()
 {
-    _loopTask.setInterval(Configuration.get().Mqtt.PublishInterval * TASK_SECOND);
+    const CONFIG_T& config = Configuration.get();
+    _loopTask.setInterval(config.Mqtt.PublishInterval * TASK_SECOND);
+
 
     if (!MqttSettings.getConnected() || !Hoymiles.isAllRadioIdle()) {
         _loopTask.forceNextIteration();
         return;
     }
+
+    // Resend LWT message as ONLINE to ensure that the MQTT broker knows that we are still alive
+    MqttSettings.publish(config.Mqtt.Lwt.Topic, config.Mqtt.Lwt.Value_Online);
 
     MqttSettings.publish("dtu/uptime", String(esp_timer_get_time() / 1000000));
     MqttSettings.publish("dtu/ip", NetworkSettings.localIP().toString());


### PR DESCRIPTION
For my setup (and as stated in [#3069](https://github.com/tbnobody/OpenDTU/issues/3069) also for multiple others) DTU got unavailable in HA after some time - fixable by restarting DTU or saving Network/MQTT config.

This fix publish the state topic in every cycle with ONLINE state to prevent marking DTU as unavailable.